### PR TITLE
Fix duplicated event name in developer docs

### DIFF
--- a/docs/developers/events.md
+++ b/docs/developers/events.md
@@ -18,7 +18,7 @@ Event::on(Feeds::class, Feeds::EVENT_BEFORE_SAVE_FEED, function(FeedEvent $event
 });
 ```
 
-### The `beforeSaveFeed` event
+### The `afterSaveFeed` event
 
 Plugins can get notified after a feed has been saved (through the control panel).
 


### PR DESCRIPTION
`beforeSaveEvent` is duplicated twice in the developer docs.