### PR TITLE
Fix documentation of the for error log level

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -44,7 +44,7 @@ return [
 - `parseTwig` - Whether to parse field data and default values for Twig. Disabled by default.
 - `compareContent` - Whether to check against existing element content before updating. This can have considerable performance improvements and prevent against needless updating.
 - `sleepTime` - Add the number of seconds to sleep after each feed item has been processed.
-- `logging` - Set the level of logging to do. Possible values are `true` (default) to log everything, `false` to disable logging or `errors` to only record errors.
+- `logging` - Set the level of logging to do. Possible values are `true` (default) to log everything, `false` to disable logging or `error` to only record errors.
 - `runGcBeforeFeed` - Whether to run the Garbage Collection service before running a feed.
 - `queueTtr` - Set the 'time to reserve' time in seconds, to prevent the job being cancelled after 300 seconds (default).
 - `queueMaxRetry` - Set the maxiumum amount of retries the queue job should have before failing.


### PR DESCRIPTION
Setting "logging" to "errors" does nothing the right value seems to be "error"