### PR TITLE
Returning feedData from beforeProcessFeed() and counting the number of items after, instead of before

### DIFF
--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -50,9 +50,11 @@ class FeedImport extends BaseJob implements RetryableJobInterface
                 return;
             }
 
-            $totalSteps = count($feedData);
-
             $feedSettings = Plugin::$plugin->process->beforeProcessFeed($this->feed, $feedData);
+
+            $feedData = $feedSettings['feedData'];
+
+            $totalSteps = count($feedData);
 
             $index = 0;
 

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -145,6 +145,9 @@ class Process extends Component
         // Allow event to modify the feed data
         $this->_data = $event->feedData;
 
+        // Return the feed data
+        $return['feedData'] = $this->_data;
+
         Plugin::info('Finished preparing for feed processing.');
 
         return $return;


### PR DESCRIPTION
The proposed changes adds the feed data returned from `EVENT_BEFORE_PROCESS_FEED` to the return array, and counts the number of items _after_ `beforeProcessFeed()` is called, instead of before. This gives the ability to actually modify the feed data via the `EVENT_BEFORE_PROCESS_FEED` event.

The change in #462 give the `EVENT_BEFORE_PROCESS_FEED` the ability to change the $feedData in the event. However, as nothing else is happening in the `beforeProcessFeed()` function, and the feed data is not part of the `$return` array returned from the function, any changes made to the actual feed data is effectively lost.

Furthermore, as the items in the feed data are counted _before_ `beforeProcessFeed()` is called, any changes to the number of items in the feed (e.g. removing duplicates), will give the wrong number of iterations in the queue.