### PR TITLE
Do not overwrite existing Linkit link type from import data or default

### DIFF
--- a/src/fields/Linkit.php
+++ b/src/fields/Linkit.php
@@ -42,7 +42,7 @@ class Linkit extends Field implements FieldInterface
             $preppedData[$subFieldHandle] = DataHelper::fetchValue($this->feedData, $subFieldInfo);
         }
 
-        if ($preppedData) {
+        if ($preppedData && empty($preppedData['type'])) {
             $preppedData['type'] = 'fruitstudios\linkit\models\Url';
         }
 


### PR DESCRIPTION
Fix for #615. Currently, whatever link type you set in either your import data or the default field in the Feed Me import settings, it gets overwritten as a Url type. This changes the behavior to only reset the link type if there is no existing data.