### PR TITLE
Fix importing default value for checkboxes and multiselects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Added a fail-safe when assigning default authors to entries to ensure lookup is always done against `elements.id` 
+
+### Fixed
+- Fixed a bug that occurred when importing default values to checkboxes and/or multiselects fields
+
 ## 4.1.2 - 2019-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## Unreleased
 
 ### Changed
-- Added a fail-safe when assigning default authors to entries to ensure lookup is always done against `elements.id` 
+- Added a fail-safe when assigning default authors to entries to ensure lookup is always done against the user’s ID. ([#627](https://github.com/craftcms/feed-me/issues/627))
 
 ### Fixed
-- Fixed a bug that occurred when importing default values to checkboxes and/or multiselects fields
+- Fixed a bug that occurred when importing default values might not occur when the options were in checkboxes and/or multiselects fields.
 
 ## 4.1.2 - 2019-08-11
 

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -175,6 +175,7 @@ class Entry extends Element
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
         $match = Hash::get($fieldInfo, 'options.match');
         $create = Hash::get($fieldInfo, 'options.create');
+        $node = Hash::get($fieldInfo, 'node');
 
         // Element lookups must have a value to match against
         if ($value === null || $value === '') {
@@ -183,6 +184,10 @@ class Entry extends Element
 
         if (is_array($value)) {
             $value = $value[0];
+        }
+
+        if ($node === 'usedefault') {
+            $match = 'elements.id';
         }
 
         if ($match === 'fullName') {

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -74,6 +74,9 @@ class DataHelper
 
         // Check if not importing, just using default
         if ($node === 'usedefault' && !$value) {
+            if (!is_array($default)) {
+                $default = [$default];
+            }
             $value = $default;
         }
 


### PR DESCRIPTION
Default values were being passed as strings which would break [here](https://github.com/craftcms/feed-me/blob/develop/src/fields/Checkboxes.php#L40) and [here](https://github.com/craftcms/feed-me/blob/develop/src/fields/MultiSelect.php#L40)