### PR TITLE
Fix _createModelFromRecord for Craft 3.4

### DIFF
--- a/src/services/Feeds.php
+++ b/src/services/Feeds.php
@@ -217,12 +217,12 @@ class Feeds extends Component
             return null;
         }
 
-        $record['elementGroup'] = Json::decode($record['elementGroup']);
-        $record['duplicateHandle'] = Json::decode($record['duplicateHandle']);
-        $record['fieldMapping'] = Json::decode($record['fieldMapping']);
-        $record['fieldUnique'] = Json::decode($record['fieldUnique']);
-
         $attributes = $record->toArray();
+
+        $attributes['elementGroup'] = Json::decode($attributes['elementGroup']);
+        $attributes['duplicateHandle'] = Json::decode($attributes['duplicateHandle']);
+        $attributes['fieldMapping'] = Json::decode($attributes['fieldMapping']);
+        $attributes['fieldUnique'] = Json::decode($attributes['fieldUnique']);
 
         foreach ($attributes as $attribute => $value) {
             $override = $this->getModelOverrides($attribute, $record['id']);
@@ -249,5 +249,4 @@ class Feeds extends Component
 
         return $feedRecord;
     }
-
 }


### PR DESCRIPTION
Fixes #643 

New in 3.4: https://github.com/craftcms/cms/blob/3.4/CHANGELOG-v3.4.md#changed

> Active record classes now normalize attribute values right when they are set.

Since feed-me was trying to decode the `Record` props directly, they were getting encoded again.

@brandonkelly Seems like this could potentially trip up other plugins that might be modifying a Record instance directly…maybe worth a warning in the changelog?