### PR TITLE
Fix issue #647

### DIFF
--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -132,7 +132,7 @@ class DataTypes extends Component
         $url = Craft::getAlias($url);
 
         // Check for local or relative URL
-        if (strpos($url, '://') === false && !UrlHelper::isProtocolRelativeUrl($url) && !UrlHelper::isRootRelativeUrl($url)) {
+        if (strpos($url, '://') === false && UrlHelper::isRootRelativeUrl($url)) {
             error_clear_last();
 
             $filepath = realpath($url);

--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -131,8 +131,8 @@ class DataTypes extends Component
 
         $url = Craft::getAlias($url);
 
-        // Check for local or relative URL
-        if (strpos($url, '://') === false && UrlHelper::isRootRelativeUrl($url)) {
+        // If the path starts with / but not //
+        if (strpos($url, '/') === 0 && !UrlHelper::isProtocolRelativeUrl($url)) {
             error_clear_last();
 
             $filepath = realpath($url);


### PR DESCRIPTION
`UrlHelper::isRootRelativeUrl($url)` should be `true` and  already checks `!UrlHelper::isProtocolRelativeUrl($url)` (previously changed [here](https://github.com/craftcms/feed-me/issues/624))