### PR TITLE
Avoid disabling elements that are already disabled

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -154,8 +154,11 @@ abstract class Element extends Component implements ElementInterface
         foreach ($elementIds as $elementId) {
             /** @var BaseElement $element */
             $element = $elementsService->getElementById($elementId, $class);
-            $element->enabled = false;
-            $elementsService->saveElement($element);
+
+            if ($element->enabled) {
+                 $element->enabled = false;
+                 $elementsService->saveElement($element);
+            }
         }
 
         return true;


### PR DESCRIPTION
Currently all elements are resaved when disabling, even if they already are disabled. This can drastically slow down the feed import. Could possibly also be changed for `disableForSite()`, as it specifically asks for any status.