### PR TITLE
Issue 760: Entry status not changing to disabled

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -175,7 +175,7 @@ class DataHelper
             }
 
             // Check for simple fields first
-            if ($existingValue == $newValue) {
+            if ($existingValue === $newValue) {
                 unset($trackedChanges[$key]);
                 continue;
             }
@@ -194,7 +194,7 @@ class DataHelper
                 $existingValue = $groups;
             }
 
-            if ($existingValue == $newValue) {
+            if ($existingValue === $newValue) {
                 unset($trackedChanges[$key]);
                 continue;
             }

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -175,7 +175,7 @@ class DataHelper
             }
 
             // Check for simple fields first
-            if ($existingValue === $newValue) {
+            if (Hash::check($fields, $key) && $existingValue == $newValue) {
                 unset($trackedChanges[$key]);
                 continue;
             }
@@ -194,7 +194,7 @@ class DataHelper
                 $existingValue = $groups;
             }
 
-            if ($existingValue === $newValue) {
+            if (Hash::check($attributes, $key) && $existingValue === $newValue) {
                 unset($trackedChanges[$key]);
                 continue;
             }

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -194,7 +194,7 @@ class DataHelper
                 $existingValue = $groups;
             }
 
-            if (Hash::check($attributes, $key) && $existingValue === $newValue) {
+            if (Hash::check($attributes, $key) && $existingValue == $newValue) {
                 unset($trackedChanges[$key]);
                 continue;
             }


### PR DESCRIPTION
### Description

A feed is unable to set an Entry's status to disabled. The issue comes down to the first value comparison check being against a non-existent value in the `$fields` array. `Hash::get()` will return a default of `null` which when compared with a double-equals comparison results in `true` and causes the difference to be thrown away. The second comparison against the `$attributes` array has the desired result since it does exist in that array. I placed the same check on Line 197 for the same purpose as on Line 178.

### Related issues

Further details of the issue can be found in the initial report on #760.