### PR TITLE
Grammar fix in migrating-from-expressionengine.md

### DIFF
--- a/docs/guides/migrating-from-expressionengine.md
+++ b/docs/guides/migrating-from-expressionengine.md
@@ -5,7 +5,7 @@ Migrating from ExpressionEngine to Craft is relatively straightforward in most c
 This guide is also aimed at ExpressionEngine 2.x. We will not be offering a guide for ExpressionEngine 3.x.
 
 :::tip
-We are unable to offer any dedicated support for exporting out of ExpressionEngine. Its essentially up to you how you get your data, and this guide is for reference only.
+We are unable to offer any dedicated support for exporting out of ExpressionEngine. It is up to you how you get your data, and this guide is for reference only.
 :::
 
 ### Create export from ExpressionEngine


### PR DESCRIPTION
"Its" was used instead of "it's," and perhaps a contraction is not suitable for documentation anyway. "Essentially" was, well, inessential.