### PR TITLE
Run all feeds

### DIFF
--- a/src/console/controllers/FeedsController.php
+++ b/src/console/controllers/FeedsController.php
@@ -83,7 +83,7 @@ class FeedsController extends Controller
 
         if ($this->all) {
             foreach($feeds->getFeeds() as $feed) {
-                $this->queueFeed($feed);
+                $this->queueFeed($feed, null, null, $this->continueOnError);
 
                 $tally++;
             }
@@ -100,7 +100,7 @@ class FeedsController extends Controller
                     continue;
                 }
 
-                $this->queueFeed($feed);
+                $this->queueFeed($feed, $this->limit, $this->offset, $this->continueOnError);
 
                 $tally++;
             }
@@ -116,9 +116,12 @@ class FeedsController extends Controller
     /**
      * Push a feed to the queue to be processed.
      *
-     * @param $feed
+     * @param      $feed
+     * @param null $limit
+     * @param null $offset
+     * @param bool $continueOnError
      */
-    protected function queueFeed($feed): void
+    protected function queueFeed($feed, $limit = null, $offset = null, $continueOnError = false): void
     {
         $this->stdout('Queuing up feed ');
         $this->stdout($feed->name, Console::FG_CYAN);
@@ -126,9 +129,9 @@ class FeedsController extends Controller
 
         $this->queue->push(new FeedImport([
             'feed' => $feed,
-            'limit' => $this->limit,
-            'offset' => $this->offset,
-            'continueOnError' => $this->continueOnError,
+            'limit' => $limit,
+            'offset' => $offset,
+            'continueOnError' => $continueOnError,
         ]));
 
         $this->stdout('done' . PHP_EOL, Console::FG_GREEN);

--- a/src/console/controllers/FeedsController.php
+++ b/src/console/controllers/FeedsController.php
@@ -7,6 +7,7 @@ use craft\feedme\Plugin;
 use craft\feedme\queue\jobs\FeedImport;
 use craft\helpers\Console;
 use craft\queue\Queue;
+use yii\base\Module;
 use yii\console\Controller;
 use yii\console\ExitCode;
 
@@ -44,9 +45,16 @@ class FeedsController extends Controller
     // Public Methods
     // =========================================================================
 
-    public function __construct()
+    /**
+     * @param string $id the ID of this controller.
+     * @param Module $module the module that this controller belongs to.
+     * @param array $config name-value pairs that will be used to initialize the object properties.
+     */
+    public function __construct($id, $module, $config = [])
     {
         $this->queue = Craft::$app->getQueue();
+
+        parent::__construct($id, $module, $config);
     }
 
     /**
@@ -65,24 +73,25 @@ class FeedsController extends Controller
     /**
      * Queues up feeds to be processed.
      *
-     * @param string $feedId A comma-separated list of feed IDs to process
+     * @param string|null $feedId A comma-separated list of feed IDs to process
      * @return int
      */
-    public function actionQueue($feedId): int
+    public function actionQueue($feedId = null): int
     {
-        $ids = explode(',', $feedId);
         $feeds = Plugin::getInstance()->getFeeds();
         $tally = 0;
 
         if ($this->all) {
-            foreach($feeds as $feed) {
+            foreach($feeds->getFeeds() as $feed) {
                 $this->queueFeed($feed);
 
                 $tally++;
             }
         }
 
-        if (! $this->all && is_array($ids)) {
+        if (! $this->all && $feedId) {
+            $ids = explode(',', $feedId);
+
             foreach ($ids as $id) {
                 $feed = $feeds->getFeedById($id);
 


### PR DESCRIPTION
### Description
Add the ability to push all feeds to the queue.

Existing functionality remains the same.
Pushing all feeds to the queue will ignore supplied id's, limit and offset. The continueOnError flag can still be passed down.

### Motivation
Building a multi-site Craft app with ever expanding sites and feed-me imports which have to be manually specified for every new feed makes it easy to forget updating the cron config. Allowing the --all tag for the command removes that.

