### PR TITLE
Local path windows bugfix

### DIFF
--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -165,7 +165,7 @@ class DataTypes extends Component
         $url = Craft::getAlias($url);
 
         // If the path starts with / but not //
-        if (strpos($url, '/') === 0 && !UrlHelper::isProtocolRelativeUrl($url)) {
+        if (file_exists($url)) {
             error_clear_last();
 
             $filepath = realpath($url);


### PR DESCRIPTION
Use file_exists instead of checking if the URL starts with a slash

### Description
Before local paths were treated as an URL on windows because the path didn't start with a slash. This pull request fixes this issue by using file_exists() to determine whether we're working with a local file.


### Related issues
https://github.com/craftcms/feed-me/issues/655
