### PR TITLE
Fix: CalendarEvent breaking on extra RRULE entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.5.2 - Unreleased
+
+### Fixed
+- Fixed `CalendarEvent` imports breaking on RRULEs with extra rules that aren't common.
+
 ## 4.3.5.1 - 2021-02-07
 
 ### Fixed

--- a/src/elements/CalenderEvent.php
+++ b/src/elements/CalenderEvent.php
@@ -26,6 +26,17 @@ use yii\base\Event;
  */
 class CalenderEvent extends Element
 {
+    const RRULE_MAP = [
+        'BYMONTH' => 'byMonth',
+        'BYYEARDAY' => 'byYearDay',
+        'BYMONTHDAY' => 'byMonthDay',
+        'BYDAY' => 'byDay',
+        'UNTIL' => 'until',
+        'INTERVAL' => 'interval',
+        'FREQ' => 'freq',
+        'COUNT' => 'count',
+    ];
+
     // Properties
     // =========================================================================
 
@@ -241,15 +252,11 @@ class CalenderEvent extends Element
             $rules = RfcParser::parseRRule($value);
 
             foreach ($rules as $ruleKey => $ruleValue) {
-                $attributes = [
-                    'BYMONTH' => 'byMonth',
-                    'BYYEARDAY' => 'byYearDay',
-                    'BYMONTHDAY' => 'byMonthDay',
-                    'BYDAY' => 'byDay',
-                ];
+                if (!array_key_exists($ruleKey, self::RRULE_MAP)) {
+                    continue;
+                }
 
-                $attribute = $attributes[$ruleKey] ?? strtolower($ruleKey);
-
+                $attribute = self::RRULE_MAP[$ruleKey];
                 if ($ruleKey === 'UNTIL') {
                     $ruleValue = new Carbon($ruleValue->format('Y-m-d H:i:s'), DateHelper::UTC);
                 }


### PR DESCRIPTION
CalendarEvent import breaks if an *RRULE* contains rules which aren't used by Calendar.

This happens because all RRULEs are being set as properties to the element even when no such properties exist.

The provided fix defines a list of all allowed RRULE properties and provides their property names, thus if the RRULE contains anything extra, it's not attached to the element attribute value list.