### PR TITLE
Sort feed data dropdown alphabetically

### DIFF
--- a/src/templates/feeds/_map.html
+++ b/src/templates/feeds/_map.html
@@ -34,10 +34,7 @@
             <input type="hidden" name="feedId" value="{{ feed.id }}">
         {% endif %}
 
-        {% set parsedFeedData = [
-            { label: 'Don’t import'|t('feed-me'), value: 'noimport' },
-            { label: "Use default value", value: 'usedefault' }
-        ] %}
+        {% set parsedFeedData = [] %}
 
         {% for key, data in feedMappingData.data %}
             {% if data is iterable %}
@@ -48,6 +45,13 @@
 
             {% set parsedFeedData = parsedFeedData|merge([{ label: '<' ~ key ~ '> eg: ' ~ snippet, value: key }]) %}
         {% endfor %}
+
+        {% set parsedFeedData = parsedFeedData|sort((a, b) => b.label < a.label) %}
+
+        {% set parsedFeedData = [
+            { label: 'Don’t import'|t('feed-me'), value: 'noimport' },
+            { label: 'Use default value', value: 'usedefault' }
+        ]|merge(parsedFeedData) %}
 
         {% include feed.element.getMappingTemplate() with { feedData: parsedFeedData } %}
 


### PR DESCRIPTION
When importing a large number of fields, the "map to feed item" dropdown on the map page is very cumbersome. Sorting the list alphabetically makes it much easier to navigate.