### PR TITLE
fix: importing asset within entry doesn't... issue #807

### DIFF
--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -318,6 +318,7 @@ class FeedMeVariable extends ServiceLocator
             'craft\fields\PositionSelect',
             'craft\fields\Radio',
             'craft\fields\Redactor',
+            'craft\redactor\Field',
         ];
 
         return in_array($class, $supportedSubFields, true);


### PR DESCRIPTION
### Description
Importing Asset within Entry doesn't allow me to specify title for the asset

Redactor fields attached to assets do not show up in the map page on feed-me.  Appears Redactor's class name changed and this change updates the supportedSubField class method to recognize the new class name.


### Related issues
Issue #807 
