### PR TITLE
Include warning about debug toolbar in troubleshooting.md

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,6 +5,7 @@
 If you're experiencing slow processing for your feed, try the following:
 
 - Turn off `devMode`. Craft's built-in logging when devMode is switched on will greatly slow down the import process, and causes a high degree of memory overhead.
+- For larger imports, make sure to disable the debug toolbar in your user account preferences as it will cause compounding memory overhead that will eventually cause memory issues
 - Consider turning on the `compareContent` [configuration setting](get-started/configuration.md#configuration-options) to prevent unnecessary content overwriting.
 - Consider selecting the Add Entries option for duplication handling, depending on your requirements.
 - Consider turning off the Backup option for the feed. This will depend on your specific circumstances.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@
 If you're experiencing slow processing for your feed, try the following:
 
 - Turn off `devMode`. Craft's built-in logging when devMode is switched on will greatly slow down the import process, and causes a high degree of memory overhead.
-- For larger imports, make sure to disable the debug toolbar in your user account preferences as it will cause compounding memory overhead that will eventually cause memory issues
+- Similarly, when importing, make sure to disable the debug toolbar under your user account preferences. It can cause high memory overhead and other resource related issues.
 - Consider turning on the `compareContent` [configuration setting](get-started/configuration.md#configuration-options) to prevent unnecessary content overwriting.
 - Consider selecting the Add Entries option for duplication handling, depending on your requirements.
 - Consider turning off the Backup option for the feed. This will depend on your specific circumstances.


### PR DESCRIPTION
### Description

Debug toolbar will crash platform on any sizeable feed-me import as it's constant calls to Yii's getRawSql causes memory leaks that eventually consume all available memory on the host machine.

