### PR TITLE
Fix #853

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fixed a bug that could occur if the feed value wasn't a `string` when importing into a dropdown field. ([#853](https://github.com/craftcms/feed-me/issues/853))
+
 ## 4.3.6 - 2021-03-05
 
 ### Added

--- a/src/fields/Dropdown.php
+++ b/src/fields/Dropdown.php
@@ -58,4 +58,12 @@ class Dropdown extends Field implements FieldInterface
 
         return null;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function fetchValue()
+    {
+        return (string) parent::fetchValue();
+    }
 }


### PR DESCRIPTION
Cast `$value` to `string` for match as this is how dropdown values are stored/returned.
