### PR TITLE
Fixes #865: Removed `mb_strtolower` in Element::parseSlug to handle allowUppercaseInSlug

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -291,8 +291,6 @@ abstract class Element extends Component implements ElementInterface
     {
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
 
-        $value = mb_strtolower($value);
-
         if (Craft::$app->getConfig()->getGeneral()->limitAutoSlugsToAscii) {
             $value = $this->_asciiString($value);
         }


### PR DESCRIPTION
### Description
`mb_strtolower` in `Element::parseSlug` breaks `allowUppercaseInSlug` configuration

### Proof it works

Was lowercased before running the feed.

![image](https://user-images.githubusercontent.com/6082025/125893158-3b9e5ceb-e865-470c-8702-5532995a0dd9.png)


### Related issues
#865