### PR TITLE
Added columnSuffix (CraftCMS 3.7+) support

### DIFF
--- a/src/templates/_includes/fields/entries.html
+++ b/src/templates/_includes/fields/entries.html
@@ -49,7 +49,9 @@
 
         {% for field in craft.app.fields.getAllFields() %}
             {% if craft.feedme.fieldCanBeUniqueId(field) %}
-                {% set matchAttributes = matchAttributes|merge({ ('field_' ~ field.handle): field.name }) %}
+                {# Check to see if we need to append columnSuffix which is added in CraftCMS 3.7 #}
+                {% set suffix = field['columnSuffix'] is defined and field.columnSuffix|length  ? '_' ~ field.columnSuffix : '' %}
+                {% set matchAttributes = matchAttributes|merge({ ('field_' ~ field.handle ~ suffix): field.name }) %}
             {% endif %}
         {% endfor %}
 


### PR DESCRIPTION
### Description
Import throws exception when importing fields that has columnSuffix defined (CraftCMS 3.7 addition).

See #864. 


