### PR TITLE
Bugfix/581 assets in wrong folder

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -267,7 +267,7 @@ class Asset extends Element
 
         $path = rtrim($value,"/");
         $folder = $assets->findFolder([
-            'name' => $path,
+            'path' => $path,
             'volumeId' => $volumeId,
         ]);
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -265,8 +265,9 @@ class Asset extends Element
             return $value;
         }
 
+        $path = rtrim($value,"/");
         $folder = $assets->findFolder([
-            'name' => $value,
+            'name' => $path,
             'volumeId' => $volumeId,
         ]);
 
@@ -279,6 +280,13 @@ class Asset extends Element
 
             // Process all folders (create them)
             foreach (explode('/', $value) as $key => $folderName) {
+                $critieria = [
+                    'name' => $folderName,
+                    'volumeId' => $volumeId,
+                ];
+                if ($lastCreatedFolder) {
+                    $critieria['parentId'] = $lastCreatedFolder->id;
+                }
                 $existingFolder = $assets->findFolder([
                     'name' => $folderName,
                     'volumeId' => $volumeId,

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -280,17 +280,14 @@ class Asset extends Element
 
             // Process all folders (create them)
             foreach (explode('/', $value) as $key => $folderName) {
-                $critieria = [
+                $criteria = [
                     'name' => $folderName,
                     'volumeId' => $volumeId,
                 ];
                 if ($lastCreatedFolder) {
-                    $critieria['parentId'] = $lastCreatedFolder->id;
+                    $criteria['parentId'] = $lastCreatedFolder->id;
                 }
-                $existingFolder = $assets->findFolder([
-                    'name' => $folderName,
-                    'volumeId' => $volumeId,
-                ]);
+                $existingFolder = $assets->findFolder($criteria);
 
                 if ($existingFolder) {
                     $lastCreatedFolder = $existingFolder;


### PR DESCRIPTION
### Description
Fixed two issues of which the more important one was responsible for creating seemingly random folders when ONLY A PART OF THE PATh STRUCTURE EXISTED in an unrelated folder.
Example: 
Two Assets: 1996/08/foo and 2021/08/bar.
First one is created correctly. For the second one, the algorithm went like this: 
2021 exists? No. Create it. 
08 exists? Yes (1996/08). Take this one. 
bar exists? No. Create it. (1996/08/bar)
This explains the assumption that the issue takes place having short folder names: The probability there is a match with just a part of the folder is higher.
To fix this issue, I added the parentId as a criterion

Moreover I fixed the first "existing" query, because the filter argument value can only match in case of a path, not just the name. 


### Related issues
#581 
