### PR TITLE
Allow `processFeed()` to accept a `feedData` attribute as an override

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -168,10 +168,11 @@ class Process extends Component
      * @param $step
      * @param $feed
      * @param $processedElementIds
+     * @param $feedData
      * @return mixed|void
      * @throws \Exception
      */
-    public function processFeed($step, $feed, &$processedElementIds)
+    public function processFeed($step, $feed, &$processedElementIds, $feedData = null)
     {
         $attributeData = [];
         $fieldData = [];
@@ -204,7 +205,7 @@ class Process extends Component
         $element = $this->_service->setModel($feed);
 
         // From the raw data in our feed, we need to fix it up so its Craft-ready for the element and fields
-        $feedData = $this->_data[$step];
+        $feedData = $feedData ?? $this->_data[$step];
 
         // We need to first find a potentially existing element, and to do that, we need to prep just the fields
         // that are selected as the unique identifier. We prep everything else later on.


### PR DESCRIPTION
Hey there!

I've managed to figure out how to handle nested importing for child elements, starting with the Comments plugin. The bulk of the work is done in the Comments plugin https://github.com/verbb/comments/commit/b4a52860097569b6239c18b71d53a1956c160861 but there's a tiny change that needs to be made on Feed Me's end. This is to facilitate custom data when calling `processFeed()` on-demand.

By default, Feed Me doesn't expect the feed data to change, so it'll prep it in `beforeProcessFeed()` and then `processFeed()` steps through each item. Not sure who thought that was a good design decision 🙄

But with these two changes, you can import nested data in one shot, with a feed structures as:

```
[
    {
        "owner": "Feed Me Owner",
        "comment": "1-1 level comment",
        "children": [
            {
                "owner": "Feed Me Owner",
                "comment": "2-1 level comment",
            },
            {
                "owner": "Feed Me Owner",
                "comment": "2-2 level comment",
                "children": [
                    {
                        "owner": "Feed Me Owner",
                        "comment": "3 level comment",
                        "children": [
                            {
                                "owner": "Feed Me Owner",
                                "comment": "4 level comment"
                            }
                        ]
                    }
                ]
            }
        ]
    },
    {
        "owner": "Feed Me Owner",
        "comment": "1-2 level comment",
    }
]
```

Where in the new behaviour introduced in Comments, you target the node that you've defined contains your child nodes -  `children` in this case. It'll then recursively look at each item in the feed for a `children` item, and if found, will shift the feed data to each child of that, and so on down the tree until it reaches the end.

As such, the structure for each child must be exactly the same, as the same mapping is used for child nodes.