### PR TITLE
Preventing array_merge_recursive with null value Fixing issue #1069 

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -103,7 +103,8 @@ class Matrix extends Field implements FieldInterface
 
                 // Finish up with the content, also sort out cases where there's array content
                 if (isset($fieldData[$key]) && is_array($fieldData[$key])) {
-                    $fieldData[$key] = array_merge_recursive($fieldData[$key], $parsedValue);
+                    $fieldData[$key] = is_array($parsedValue) ? array_merge_recursive($fieldData[$key], $parsedValue)
+                        : $fieldData[$key];
                 } else {
                     $fieldData[$key] = $parsedValue;
                 }

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -314,6 +314,14 @@ class DataHelper
         /** @noinspection TypeUnsafeComparisonInspection */
         // String length comparison to take into account "637" and "0637"
         // Should probably do a strict check, but doing this for backwards compatibility.
-        return Hash::check($fields, $key) && ($firstValue == $secondValue && mb_strlen($firstValue) === mb_strlen($secondValue));
+        if (is_string($firstValue) && is_string($secondValue)) {
+            //Only do this when you know you're dealing with strings!
+            $strlenCheck = mb_strlen($firstValue) === mb_strlen($secondValue);
+        }
+        else {
+            //Default behaviour before string length checks were introduced (and caused type errors)
+            $strlenCheck = true;
+        }
+        return Hash::check($fields, $key) && ($firstValue == $secondValue) && $strlenCheck;
     }
 }


### PR DESCRIPTION
### Description
Catching the condition that the parsed field returns a null value and the Matrix field tries to merge this with an array. 


### Related issues
#1069
