### PR TITLE
Added settings option enableStringReplace so empty strings overwrite existing values

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -147,6 +147,11 @@ class DataHelper
             $value = $default;
         }
 
+        // If emptyStringReplace setting is enabled, send $value overwrite existing data
+        if ($value === "" && Plugin::$plugin->getSettings()->emptyStringReplace) {
+            return $value;
+        }
+
         // We want to preserve 0 and '0', but if it's empty, return null.
         // https://github.com/craftcms/feed-me/issues/779
         if (!is_numeric($value) && empty($value)) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -20,6 +20,11 @@ class Settings extends Model
     public $cache = 60;
 
     /**
+     * @var bool
+     */
+    public $emptyStringReplace = false;
+
+    /**
      * @var string
      */
     public $enabledTabs = '*';

--- a/src/templates/settings/general.html
+++ b/src/templates/settings/general.html
@@ -29,7 +29,8 @@
     }) }}
 
     {{ forms.lightswitchField({
-        label: 'Empty strings overwrite previous values'|t('feed-me'),
+        label: 'Empty Strings Overwrite Values'|t('feed-me'),
+        instructions: 'Empty string values by default do not overwrite existing data when updating records, enabling this allows empty string values to overwrite data'|t('feed-me'),
         name: 'emptyStringReplace',
         on: settings.emptyStringReplace
     }) }}

--- a/src/templates/settings/general.html
+++ b/src/templates/settings/general.html
@@ -28,6 +28,12 @@
         instructions: 'Cache duration (in seconds) to cache requests. Note: this only affects calls using the template tag - requests are never cached when triggering directly via the CP.'|t('feed-me'),
     }) }}
 
+    {{ forms.lightswitchField({
+        label: 'Empty strings overwrite previous values'|t('feed-me'),
+        name: 'emptyStringReplace',
+        on: settings.emptyStringReplace
+    }) }}
+
     <hr>
 
     {{ forms.checkboxSelectField({


### PR DESCRIPTION
### Description
This adds a setting to allow empty strings to overwrite existing values.

### Related issues
#797 

