### PR TITLE
Fixes invalid argument issue in SuperTable

### DIFF
--- a/src/fields/SuperTable.php
+++ b/src/fields/SuperTable.php
@@ -165,6 +165,10 @@ class SuperTable extends Field implements FieldInterface
         $feedPath = preg_replace('/(\/\d+\/)/', '/', $nodePath);
         $feedPath = preg_replace('/^(\d+\/)|(\/\d+)/', '', $feedPath);
 
+        if (!$fields) {
+            return null;
+        }
+
         foreach ($fields as $subFieldHandle => $subFieldInfo) {
             $node = Hash::get($subFieldInfo, 'node');
 


### PR DESCRIPTION
### Description

Experienced an "invalid argument for foreach on line 168 of SuperTable.php. Tracked to this, and feed is now importing when I want to run a feed against a type that has a supertable but I don't want feed me to do anything with it.

![screenshot--2022-02-08 at 11 35 10](https://user-images.githubusercontent.com/350834/152979494-b93d259a-2c6b-4c28-b12b-6b2fafd65bd1.png)

### Related issues

