### PR TITLE
Fix Craft 4 feed processing errors

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -4,6 +4,7 @@ namespace craft\feedme\base;
 
 use ArrayAccess;
 use Cake\Utility\Hash;
+use Carbon\Carbon;
 use Craft;
 use craft\base\Component;
 use craft\base\Element as BaseElement;
@@ -326,8 +327,11 @@ abstract class Element extends Component implements ElementInterface
     protected function parseDateAttribute($value, $formatting): ?DateTime
     {
         $dateValue = DateHelper::parseString($value, $formatting);
+        if ($dateValue instanceof Carbon) {
+            $dateValue = $dateValue->toDateTime();
+        }
 
-        if (!is_null($dateValue)) {
+        if (!empty($dateValue)) {
             return $dateValue;
         }
 

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -197,7 +197,7 @@ class Entry extends Element
         $element = $query->one();
 
         if ($element) {
-            $this->element->newParentId = $element->id;
+            $this->element->setParent($element);
 
             return $element->id;
         }

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -130,7 +130,6 @@ class Entries extends Field implements FieldInterface
             }
 
             $criteria['status'] = null;
-            // $criteria['enabledForSite'] = false;
             $criteria['sectionId'] = $sectionIds;
             $criteria['limit'] = $limit;
             $criteria['where'] = ['=', $columnName, $dataValue];

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -130,7 +130,7 @@ class Entries extends Field implements FieldInterface
             }
 
             $criteria['status'] = null;
-            $criteria['enabledForSite'] = false;
+            // $criteria['enabledForSite'] = false;
             $criteria['sectionId'] = $sectionIds;
             $criteria['limit'] = $limit;
             $criteria['where'] = ['=', $columnName, $dataValue];


### PR DESCRIPTION
### Description
This addresses a few issues we ran into while testing out feed processing in `5.0.0-beta.2` on a site running Craft `4.0.0-RC1`.

**Date Processing**
With the `?DateTime` return type added to `Element::parseDateAttribute()`, feeds setting a date (like a `postDate` or `expiryDate`) would throw some variation of:

```
craft\\feedme\\base\\Element::parseDateAttribute(): Return value must be of type ?DateTime, string returned - Element.php: 331
```

This flattens any returned `Carbon` instances down to a raw `DateTime`, and ensures empty strings and arrays are returned as `null`.

**Parent Attachment**
Feeds attaching an element to a parent would throw

```
Setting unknown property: craft\\elements\\Entry::newParentId - Component.php: 209
```

This swaps the old `newParentId` property for `->setParent()`.


**Entries Field Site Status**
Feeds importing values into an entries field would throw 
```
Setting unknown property: craft\elements\db\EntryQuery::enabledForSite - Component.php: 209
```

This comments out the `enabledForSite` key in the criteria array, the same way the original Craft 4 PR [commented it out](https://github.com/craftcms/feed-me/pull/1111/files#diff-5f792cd4c711263de882c2b77648c06b96220acfb045d42bdc14b142a4d9ebe7R168) higher up in the same file.
