### PR TITLE
Replace `newParentId` with `setParentId()`

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -197,7 +197,7 @@ class Entry extends Element
         $element = $query->one();
 
         if ($element) {
-            $this->element->newParentId = $element->id;
+            $this->element->setParentId($element->id);
 
             return $element->id;
         }


### PR DESCRIPTION
Craft 4 has ditched the `newParentId` property, so we need to use `setParentId()`. For some reason, `$element->parentId = 123` doesn't seem to work, despite the setter there, as I've found for https://github.com/verbb/comments/commit/83f83adea83274630379d479413ae30c03566b35 and https://github.com/verbb/navigation/commit/7a0b4bcd6e9ce82dcefd200ab515eefe29f8b6f4