### PR TITLE
Csv: Fix unintended cast

### DIFF
--- a/src/datatypes/Csv.php
+++ b/src/datatypes/Csv.php
@@ -119,7 +119,7 @@ class Csv extends DataType implements DataTypeInterface
      * @return array
      * @throws \League\Csv\Exception
      */
-    private function _getRows($reader): array
+    private function _getRows($reader): mixed
     {
         // We try to first fetch the first row in the CSV which we figure is the headers. But if it's not
         // it'll throw an error saying the first row of the CSV isn't valid, and not unique, etc.
@@ -145,14 +145,14 @@ class Csv extends DataType implements DataTypeInterface
         try {
             $reader->setHeaderOffset(0);
 
-            return (array)$stmt->process($reader);
+            return $stmt->process($reader);
         } catch (Throwable $e) {
         }
 
         // Support for league/csv v9 without a header
         $reader->setHeaderOffset(null);
 
-        return (array)$stmt->process($reader);
+        return $stmt->process($reader);
     }
 
     /**


### PR DESCRIPTION
### Description

League CSV 9's ResultSet is an object and casting it to an array causes chaotic behavior. Just keep it as mixed.

CSV reader in 5.0 has been consistently malfunctioning in unpredictable ways, e.g. reporting different element count or reporting errors that are not at all helpful.