### PR TITLE
Add known limitations

### DIFF
--- a/docs/get-started/limitations.md
+++ b/docs/get-started/limitations.md
@@ -1,0 +1,7 @@
+# Limitations
+
+FeedMe tries its best to cover as many use cases as possible to facilitate ingestion of content into Craft. There are, however, some known limitations that you should be aware of.
+
+## Multilanguage sites and Matrix fields
+
+When importing content in a site part of a group and in a multi-language scenario, FeedMe is unable to selectively update content for a specific language for matrix blocks and will end up overwriting the field content for all sites and languages in the site group.


### PR DESCRIPTION
### Description

This PR provides initial documentation for known limitations of the plugin, such as the near impossibility of importing matrix blocks in multilanguage sites (see #1156).

I believe it is important for users to know beforehand what they can and cannot expect from FeedMe, to avoid planning complex and large migrations that can potentially fail due to known limitations.

This is a first attempt and language and tone can definitively benefit from a review for consistency but the goal of the PR stands regardless.

### Related issues

- #1156