### PR TITLE
Added Register Complex Fields event

### DIFF
--- a/src/events/RegisterFeedMeComplexFieldsEvent.php
+++ b/src/events/RegisterFeedMeComplexFieldsEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace craft\feedme\events;
+
+use yii\base\Event;
+
+class RegisterFeedMeComplexFieldsEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var array
+     */
+    public array $complexFields = [];
+}


### PR DESCRIPTION
### Description
Fixes bug that parses table fields incorrectly for Commerce Variants.
Adds ability for plugin developers to register their fields as 'complex fields' which also lets them be parsed correctly for Commerce Variants.


### Related issues
https://github.com/craftcms/feed-me/issues/1168
