### PR TITLE
Properly show sub fields

### DIFF
--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -233,7 +233,7 @@ class FeedMeVariable extends ServiceLocator
             return null;
         }
 
-        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->fieldLayoutId)) === null) {
+        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->fieldLayoutId)) !== null) {
             return $fieldLayout->getCustomFields();
         }
 
@@ -248,7 +248,7 @@ class FeedMeVariable extends ServiceLocator
             return null;
         }
 
-        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($layoutId)) === null) {
+        if (($fieldLayout = Craft::$app->getFields()->getLayoutById($layoutId)) !== null) {
             return $fieldLayout->getCustomFields();
         }
 


### PR DESCRIPTION
### Description
The `null` check was flipped, which meant that subfields wouldn't show when they existed. 
