### PR TITLE
Allow commerce import when logged out

### DIFF
--- a/src/elements/CommerceProduct.php
+++ b/src/elements/CommerceProduct.php
@@ -107,7 +107,10 @@ class CommerceProduct extends Element
      */
     public function getGroups(): array
     {
-        if (Commerce::getInstance()) {
+        // Fix for https://github.com/craftcms/feed-me/issues/1199
+        $user = Craft::$app->getUser()->getIdentity();
+
+        if (Commerce::getInstance() && $user) {
             return Commerce::getInstance()->getProductTypes()->getEditableProductTypes();
         }
 


### PR DESCRIPTION
Fixes an issue where running an import via URL would error out because `getEditableProductTypes` assumes that the user exists.

Fixes #1199