### PR TITLE
Fix enabled logic

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -383,6 +383,9 @@ class Process extends Component
             }
 
             $enabledForSite[$element->siteId] = $attributeData['enabled'];
+
+            // Set the global status to true if it's enabled for *any* sites, or if already enabled.
+            $element->enabled = in_array(true, $enabledForSite) || $element->enabled;
             $element->setEnabledForSite($enabledForSite);
         }
 


### PR DESCRIPTION
The `enabledForSite` property was getting set correctly, but the `enabled` property didn't necessarily respect it. This caused elements to appear as if their status was incorrect and could cause some issues if you tried to change it via an element action.

Fixes #1208

