### PR TITLE
Fixes compareElementContent

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -228,7 +228,7 @@ class DataHelper
                 $existingValue = $groups;
             }
 
-            if (self::_compareSimpleValues($fields, $key, $existingValue, $newValue)) {
+            if (self::_compareSimpleValues($attributes, $key, $existingValue, $newValue)) {
                 unset($trackedChanges[$key]);
                 continue;
             }


### PR DESCRIPTION
When you would import any of an elements attributes, say its title, then this would always conclude that the value changed because it was comparing its hash in the wrong array

`$value` contains the values of custom fields, `$attributes` contains the values of element attributes such as its title.

This bug causes all imports, that import any of the attributes, to always conclude that the data changed.  This results in more database work and also a new revision for every entry on every import.

Resolves #1219