### PR TITLE
Compare $attributes not $fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added 
 - Added a feed setting that allows feeds to specify if they'd like empty values to used to overwrite existing data. ([#1228](https://github.com/craftcms/feed-me/pull/1228), [#797](https://github.com/craftcms/feed-me/issues/797), [#723](https://github.com/craftcms/feed-me/issues/723), [#854](https://github.com/craftcms/feed-me/issues/854), [#680](https://github.com/craftcms/feed-me/issues/680))
 
+### Fixed
+- Fixed a bug where some feed element data would be considered changed even if there were no changes. ([#1220](https://github.com/craftcms/feed-me/pull/1220), [#1219](https://github.com/craftcms/feed-me/issues/1219)
+
 ## 4.5.4 - 2023-01-09
 
 ### Fixed

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -224,7 +224,7 @@ class DataHelper
                 $existingValue = $groups;
             }
 
-            if (self::_compareSimpleValues($fields, $key, $existingValue, $newValue)) {
+            if (self::_compareSimpleValues($attributes, $key, $existingValue, $newValue)) {
                 unset($trackedChanges[$key]);
                 continue;
             }


### PR DESCRIPTION
Same fix as #1218, just onto the v4 branch instead.

@boudewijn-zicht deserves all the credit.

It looks like this was originally `$attributes` but accidentally got swapped to `$fields` in the [`__compareSimpleValues` refactor](https://github.com/craftcms/feed-me/commit/704d511e85adba8caca7a90644c29e78b0a3490a)

Fixes #1219 
