### PR TITLE
Feature/native alt field support

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -12,6 +12,7 @@ use craft\feedme\Plugin;
 use craft\helpers\Json;
 use Throwable;
 use yii\base\Exception;
+use yii\base\InvalidConfigException;
 
 /**
  *
@@ -134,7 +135,18 @@ abstract class Field extends Component
     // Protected Methods
     // =========================================================================
 
-    protected function populateFields($elementIds, $fieldType = 'custom')
+    /**
+     * Populate values on an element.
+     *
+     * @param array $elementIds Array of elementIds to populate.
+     * @param string $fieldType Type of field to populate, can be `custom` or `native`.
+     * @return void
+     * @throws ElementNotFoundException
+     * @throws Exception
+     * @throws Throwable
+     * @throws InvalidConfigException
+     */
+    protected function populateFields(array $elementIds, string $fieldType = 'custom'): void
     {
         $elementsService = Craft::$app->getElements();
         $key = $fieldType === 'custom' ? 'fields' : 'nativeFields';

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -10,7 +10,6 @@ use craft\errors\ElementNotFoundException;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 use craft\helpers\Json;
-use Symfony\Component\VarDumper\Cloner\Data;
 use Throwable;
 use yii\base\Exception;
 

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -205,5 +205,4 @@ class Assets extends Field implements FieldInterface
 
         return $foundElements;
     }
-
 }

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -70,7 +70,7 @@ class Assets extends Field implements FieldInterface
         $upload = Hash::get($this->fieldInfo, 'options.upload');
         $conflict = Hash::get($this->fieldInfo, 'options.conflict');
         $fields = Hash::get($this->fieldInfo, 'fields');
-        $alt = Hash::get($this->fieldInfo, 'alt');
+        $nativeFields = Hash::get($this->fieldInfo, 'nativeFields');
         $node = Hash::get($this->fieldInfo, 'node');
 
         // Get folder id's for connecting
@@ -188,8 +188,12 @@ class Assets extends Field implements FieldInterface
         }
 
         // Check for any sub-fields for the element
-        if ($fields || $alt) {
+        if ($fields) {
             $this->populateElementFields($foundElements);
+        }
+
+        if ($nativeFields) {
+            $this->populateNativeFields($foundElements);
         }
 
         $foundElements = array_unique($foundElements);
@@ -201,4 +205,5 @@ class Assets extends Field implements FieldInterface
 
         return $foundElements;
     }
+
 }

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -70,6 +70,7 @@ class Assets extends Field implements FieldInterface
         $upload = Hash::get($this->fieldInfo, 'options.upload');
         $conflict = Hash::get($this->fieldInfo, 'options.conflict');
         $fields = Hash::get($this->fieldInfo, 'fields');
+        $alt = Hash::get($this->fieldInfo, 'alt');
         $node = Hash::get($this->fieldInfo, 'node');
 
         // Get folder id's for connecting
@@ -187,7 +188,7 @@ class Assets extends Field implements FieldInterface
         }
 
         // Check for any sub-fields for the element
-        if ($fields) {
+        if ($fields || $alt) {
             $this->populateElementFields($foundElements);
         }
 

--- a/src/templates/_includes/elements/assets/map.html
+++ b/src/templates/_includes/elements/assets/map.html
@@ -95,6 +95,18 @@
 
                     {% include template ignore missing with variables only %}
                 {% endfor %}
+
+                {% for layoutField in tab.getElements()|filter(e => e is instance of('craft\\fieldlayoutelements\\assets\\AltField')) %}
+                    {% set variables = {
+                        name: 'Alt Text',
+                        handle: 'alt',
+                        feed: feed,
+                        feedData: feedData,
+                        attribute: true,
+                    } %}
+
+                    {% include 'feed-me/_includes/fields/default' ignore missing with variables only %}
+                {% endfor %}
             </tbody>
         </table>
     {% endfor %}

--- a/src/templates/_includes/fields/_base.html
+++ b/src/templates/_includes/fields/_base.html
@@ -190,7 +190,7 @@
             {% if parentPath is defined %}
                 {% set path = parentPath|merge([ 'fields', elementFieldHandle ]) %}
             {% elseif attribute %}
-                {% set path = [ handle, attribute ] %}
+                {% set path = [ handle, 'nativeFields', attribute ] %}
             {% else %}
                 {% set path = [ handle, 'fields', elementFieldHandle ] %}
             {% endif %}

--- a/src/templates/_includes/fields/_base.html
+++ b/src/templates/_includes/fields/_base.html
@@ -187,7 +187,9 @@
             {% set attribute = elementField['attribute'] ?? null %}
             {% set elementFieldHandle = elementField['handle'] ?? attribute ?? '' %}
 
-            {% if parentPath is defined %}
+            {% if parentPath is defined and attribute %}
+                {% set path = parentPath|merge([ 'nativeFields', elementFieldHandle ]) %}
+            {% elseif parentPath is defined %}
                 {% set path = parentPath|merge([ 'fields', elementFieldHandle ]) %}
             {% elseif attribute %}
                 {% set path = [ handle, 'nativeFields', attribute ] %}

--- a/src/templates/_includes/fields/_base.html
+++ b/src/templates/_includes/fields/_base.html
@@ -184,21 +184,25 @@
         {% for elementField in elementFields %}
             {% set fieldClass = craft.feedme.fields.getRegisteredField(className(elementField)) %}
             {% set template = fieldClass.getMappingTemplate() %}
+            {% set attribute = elementField['attribute'] ?? null %}
+            {% set elementFieldHandle = elementField['handle'] ?? attribute ?? '' %}
 
             {% if parentPath is defined %}
-                {% set path = parentPath|merge([ 'fields', elementField.handle ]) %}
+                {% set path = parentPath|merge([ 'fields', elementFieldHandle ]) %}
+            {% elseif attribute %}
+                {% set path = [ handle, attribute ] %}
             {% else %}
-                {% set path = [ handle, 'fields', elementField.handle ] %}
+                {% set path = [ handle, 'fields', elementFieldHandle ] %}
             {% endif %}
 
             {# Be smart about what we include to child field templates #}
             {% include template ignore missing with {
-                name: elementField.name,
-                handle: elementField.handle,
-                instructionHandle: elementField.handle,
+                name: elementField['name'] ?? elementField['label'] ?? '',
+                attribute: elementField['attribute'] ?? null,
+                handle: elementFieldHandle,
+                instructionHandle: elementFieldHandle,
                 isSubElementField: true,
                 path: path,
-
                 feed: feed,
                 feedData: feedData,
                 field: elementField,

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -341,7 +341,7 @@ class FeedMeVariable extends ServiceLocator
             Number::class,
             PlainText::class,
             RadioButtons::class,
-            AltField::class
+            AltField::class,
         ];
 
         return in_array($class, $supportedSubFields, true);

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -5,6 +5,7 @@ namespace craft\feedme\web\twig\variables;
 use Craft;
 use craft\elements\User as UserElement;
 use craft\feedme\Plugin;
+use craft\fieldlayoutelements\assets\AltField;
 use craft\fields\Checkboxes;
 use craft\fields\Color;
 use craft\fields\Date;
@@ -16,6 +17,7 @@ use craft\fields\Number;
 use craft\fields\PlainText;
 use craft\fields\RadioButtons;
 use craft\fields\Url;
+use craft\helpers\ArrayHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\UrlHelper;
 use craft\models\CategoryGroup;
@@ -234,7 +236,7 @@ class FeedMeVariable extends ServiceLocator
         }
 
         if (($fieldLayout = Craft::$app->getFields()->getLayoutById($source->fieldLayoutId)) !== null) {
-            return $fieldLayout->getCustomFields();
+            return ArrayHelper::merge($fieldLayout->getCustomFields(), $fieldLayout->getAvailableNativeFields());
         }
 
         return null;
@@ -339,6 +341,7 @@ class FeedMeVariable extends ServiceLocator
             Number::class,
             PlainText::class,
             RadioButtons::class,
+            AltField::class
         ];
 
         return in_array($class, $supportedSubFields, true);


### PR DESCRIPTION
### Description
Adds support for native fields, specifically aimed at the native `alt` field. Native fields are set with `$element->setAttributes()` rather than `$element->setFieldValues()` which makes this a little more involved. 

If support for more native fields needs to be added in the future, as long as they are mapped to a `nativeFields` key on the `$fieldInfo` they will be saved appropriately.

### Related issues
Fixes #1194
