### PR TITLE
Fixes comparison of DateTime fields during import

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -195,6 +195,11 @@ class DataHelper
             $existingValue = Hash::get($fields, $key);
 
             // If date value, make sure to cast it as a string to compare
+            if ($existingValue instanceof \DateTime || DateTimeHelper::isIso8601($existingValue)) {
+                $existingValue = Db::prepareDateForDb($existingValue);
+            }
+            
+            // If date value, make sure to cast it as a string to compare
             if ($newValue instanceof \DateTime || DateTimeHelper::isIso8601($newValue)) {
                 $newValue = Db::prepareDateForDb($newValue);
             }
@@ -212,6 +217,11 @@ class DataHelper
 
             // Then check for simple attributes
             $existingValue = Hash::get($attributes, $key);
+            
+            // If date value, make sure to cast it as a string to compare
+            if ($existingValue instanceof \DateTime || DateTimeHelper::isIso8601($existingValue)) {
+                $existingValue = Db::prepareDateForDb($existingValue);
+            }
 
             // Check for attribute groups - more than simple asset
             if ($key === 'groups') {


### PR DESCRIPTION
The `$newValue` for DateTime instances is normalized to a string, however, this is not done for `$existingValue`.  Therefore the comparison will always conclude that the value changed because `new \DateTime('2023-01-23') != '2023-01-23'`.

This bug causes all imports, that import any of the attributes, to always conclude that the data changed. This results in more database work and also a new revision for every entry on every import.

Resolves https://github.com/craftcms/feed-me/issues/1219