### PR TITLE
Feature/relational field default value amends

### DIFF
--- a/src/templates/_includes/fields/_base.html
+++ b/src/templates/_includes/fields/_base.html
@@ -168,6 +168,7 @@
                                 selectionLabel: default.options.selectionLabel,
                                 limit: default.options.limit ?? null,
                                 elements: elements,
+                                sources: default.options.sources ?? '*',
                             }) }}
 
                         {% endif %}

--- a/src/templates/_includes/fields/calendar-events.html
+++ b/src/templates/_includes/fields/calendar-events.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Event"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/categories.html
+++ b/src/templates/_includes/fields/categories.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Category"|t('feed-me'),
+            sources: field.source ? [field.source] : '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/commerce_products.html
+++ b/src/templates/_includes/fields/commerce_products.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Product"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/commerce_variants.html
+++ b/src/templates/_includes/fields/commerce_variants.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Variant"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/digital-products.html
+++ b/src/templates/_includes/fields/digital-products.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Product"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/entries.html
+++ b/src/templates/_includes/fields/entries.html
@@ -18,6 +18,7 @@
             elementType: fieldClass.elementType,
             criteria: {'status' : null},
             selectionLabel: "Default Entry"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/tags.html
+++ b/src/templates/_includes/fields/tags.html
@@ -17,7 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Tag"|t('feed-me'),
-            sources: field.sources ?? '*',
+            sources: field.source ? [field.source] : '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/tags.html
+++ b/src/templates/_includes/fields/tags.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default Tag"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}

--- a/src/templates/_includes/fields/users.html
+++ b/src/templates/_includes/fields/users.html
@@ -17,6 +17,7 @@
         options: {
             elementType: fieldClass.elementType,
             selectionLabel: "Default User"|t('feed-me'),
+            sources: field.sources ?? '*',
         },
     } %}
 {% endif %}


### PR DESCRIPTION
### Description
At the moment, when mapping relational fields for import, the default value modal shows all available sources and not just the sources allowed for the field.

This PR limits the default value option to the sources specified for the field. It’s applied to all relational fields supported by Feed Me, except for the assets field (as per our chat on 23/01/2023).

I’m worried that this could be considered a breaking change, though. Happy to discuss this further, and maybe it should be postponed until the Craft 5 release.


### Related issues

