### PR TITLE
Bugfix/1195 use defaults if mapped val empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Fixed a bug where some feed element data would be considered changed even if there were no changes. ([#1220](https://github.com/craftcms/feed-me/pull/1220), [#1219](https://github.com/craftcms/feed-me/issues/1219), [#1223](https://github.com/craftcms/feed-me/pull/1223/), [#1219](https://github.com/craftcms/feed-me/issues/1219))
 - Fixed a bug where the default value modal for relational fields on the feed mapping page would show all available sources and not just the sources allowed for the field. ([#1234](https://github.com/craftcms/feed-me/pull/1234))
+- Fixed a PHP error that could occur when you map an assets field with a default value and there is an empty value in the feed. ([#1229](https://github.com/craftcms/feed-me/pull/1229), [#1195](https://github.com/craftcms/feed-me/issues/1195), [#1106](https://github.com/craftcms/feed-me/issues/1106), [#1223](https://github.com/craftcms/feed-me/pull/1223/), [#1154](https://github.com/craftcms/feed-me/issues/1154))
 
 ## 4.5.4 - 2023-01-09
 

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -120,6 +120,14 @@ abstract class Field extends Component
     }
 
     /**
+     * @return array|\ArrayAccess|mixed
+     */
+    public function fetchDefaultArrayValue()
+    {
+        return DataHelper::fetchDefaultArrayValue($this->fieldInfo);
+    }
+
+    /**
      * @return array|\ArrayAccess|mixed|null
      */
     public function fetchValue()

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -7,6 +7,7 @@ use Craft;
 use craft\elements\Entry as EntryElement;
 use craft\elements\User as UserElement;
 use craft\feedme\base\Element;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\models\ElementGroup;
 use craft\feedme\Plugin;
 use craft\models\Section;
@@ -169,13 +170,19 @@ class Entry extends Element
     protected function parseParent($feedData, $fieldInfo)
     {
         $value = $this->fetchSimpleValue($feedData, $fieldInfo);
+        $default = DataHelper::fetchDefaultArrayValue($fieldInfo);
 
         $match = Hash::get($fieldInfo, 'options.match');
         $create = Hash::get($fieldInfo, 'options.create');
+        $node = Hash::get($fieldInfo, 'node');
 
         // Element lookups must have a value to match against
         if ($value === null || $value === '') {
             return null;
+        }
+
+        if ($node === 'usedefault') {
+            $match = 'elements.id';
         }
 
         $query = EntryElement::find()
@@ -208,6 +215,14 @@ class Entry extends Element
             }
 
             return $element->id;
+        }
+
+        // use the default value if it's provided and none of the above worked
+        // https://github.com/craftcms/feed-me/issues/1154
+        if (!empty($default)) {
+            $this->element->newParentId = $default[0];
+
+            return $default[0];
         }
 
         return null;

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -9,6 +9,7 @@ use craft\elements\Asset as AssetElement;
 use craft\elements\User as UserElement;
 use craft\feedme\base\Element;
 use craft\feedme\helpers\AssetHelper;
+use craft\feedme\helpers\DataHelper;
 use craft\helpers\UrlHelper;
 use craft\records\User as UserRecord;
 
@@ -180,6 +181,7 @@ class User extends Element
     protected function parseGroups($feedData, $fieldInfo)
     {
         $value = $this->fetchArrayValue($feedData, $fieldInfo);
+        $default = DataHelper::fetchDefaultArrayValue($fieldInfo);
 
         $newGroupsIds = [];
 
@@ -203,6 +205,10 @@ class User extends Element
             }
 
             $newGroupsIds[] = $result['id'];
+        }
+
+        if (empty(array_filter($value)) && !empty($default)) {
+            $newGroupsIds = $default;
         }
 
         $removeFromExisting = Hash::get($fieldInfo, 'options.removeFromExisting');

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -60,6 +60,7 @@ class Assets extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $settings = Hash::get($this->field, 'settings');
         $folders = Hash::get($this->field, 'settings.sources');
@@ -104,7 +105,7 @@ class Assets extends Field implements FieldInterface
 
         foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -113,10 +114,11 @@ class Assets extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -113,6 +113,12 @@ class Assets extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
+                break;
+            }
 
             $query = AssetElement::find();
 

--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -53,6 +53,7 @@ class CalendarEvents extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -78,9 +79,9 @@ class CalendarEvents extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -89,10 +90,11 @@ class CalendarEvents extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -78,7 +78,7 @@ class CalendarEvents extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -87,6 +87,12 @@ class CalendarEvents extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -55,6 +55,7 @@ class Categories extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $source = Hash::get($this->field, 'settings.source');
         $branchLimit = Hash::get($this->field, 'settings.branchLimit');
@@ -75,9 +76,9 @@ class Categories extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -86,10 +87,11 @@ class Categories extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -75,7 +75,7 @@ class Categories extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -84,6 +84,12 @@ class Categories extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/Checkboxes.php
+++ b/src/fields/Checkboxes.php
@@ -45,6 +45,7 @@ class Checkboxes extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $preppedData = [];
 
@@ -54,6 +55,11 @@ class Checkboxes extends Field implements FieldInterface
         foreach ($options as $option) {
             foreach ($value as $dataValue) {
                 if ($dataValue === $option[$match]) {
+                    $preppedData[] = $option['value'];
+                }
+                // special case for when mapping by label, but also using a default value
+                // which relies on $option['value']
+                if (empty($dataValue) && in_array($option['value'], $default)) {
                     $preppedData[] = $option['value'];
                 }
             }

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -79,7 +79,7 @@ class CommerceProducts extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -88,6 +88,12 @@ class CommerceProducts extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -54,6 +54,7 @@ class CommerceProducts extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -79,9 +80,9 @@ class CommerceProducts extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -90,10 +91,11 @@ class CommerceProducts extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -78,7 +78,7 @@ class CommerceVariants extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -87,6 +87,12 @@ class CommerceVariants extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -53,6 +53,7 @@ class CommerceVariants extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -78,9 +79,9 @@ class CommerceVariants extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -89,10 +90,11 @@ class CommerceVariants extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -80,7 +80,7 @@ class DigitalProducts extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -89,6 +89,12 @@ class DigitalProducts extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -55,6 +55,7 @@ class DigitalProducts extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -80,9 +81,9 @@ class DigitalProducts extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -91,10 +92,11 @@ class DigitalProducts extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -55,6 +55,7 @@ class Entries extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -89,9 +90,9 @@ class Entries extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -100,10 +101,11 @@ class Entries extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -89,7 +89,7 @@ class Entries extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -98,6 +98,12 @@ class Entries extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/MultiSelect.php
+++ b/src/fields/MultiSelect.php
@@ -45,6 +45,7 @@ class MultiSelect extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $preppedData = [];
 
@@ -57,7 +58,12 @@ class MultiSelect extends Field implements FieldInterface
                 continue;
             }
             foreach ($value as $dataValue) {
-                if ($dataValue === $option[$match]) {
+                if (!empty($dataValue) && $dataValue === $option[$match]) {
+                    $preppedData[] = $option['value'];
+                }
+                // special case for when mapping by label, but also using a default value
+                // which relies on $option['value']
+                if (empty($dataValue) && in_array($option['value'], $default)) {
                     $preppedData[] = $option['value'];
                 }
             }

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -56,6 +56,7 @@ class Tags extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $source = Hash::get($this->field, 'settings.source');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -76,9 +77,9 @@ class Tags extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -87,10 +88,11 @@ class Tags extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -76,7 +76,7 @@ class Tags extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -85,6 +85,12 @@ class Tags extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -56,6 +56,7 @@ class Users extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchArrayValue();
+        $default = $this->fetchDefaultArrayValue();
 
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -82,9 +83,9 @@ class Users extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $key => $dataValue) {
+        foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue)) {
+            if (empty($dataValue) && empty($default)) {
                 continue;
             }
 
@@ -93,10 +94,11 @@ class Users extends Field implements FieldInterface
                 $foundElements = $value;
                 break;
             }
+
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if ($key === 'elementIds') {
-                $foundElements = $dataValue;
+            if (empty($dataValue) && !empty($default)) {
+                $foundElements = $default;
                 break;
             }
 

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -82,7 +82,7 @@ class Users extends Field implements FieldInterface
             return $foundElements;
         }
 
-        foreach ($value as $dataValue) {
+        foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue)) {
                 continue;
@@ -91,6 +91,12 @@ class Users extends Field implements FieldInterface
             // If we're using the default value - skip, we've already got an id array
             if ($node === 'usedefault') {
                 $foundElements = $value;
+                break;
+            }
+            // special provision for falling back on default BaseRelationField value
+            // https://github.com/craftcms/feed-me/issues/1195
+            if ($key === 'elementIds') {
+                $foundElements = $dataValue;
                 break;
             }
 

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -5,6 +5,7 @@ namespace craft\feedme\helpers;
 use Cake\Utility\Hash;
 use Craft;
 use craft\feedme\Plugin;
+use craft\fields\BaseRelationField;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 
@@ -50,6 +51,8 @@ class DataHelper
 
         $node = Hash::get($fieldInfo, 'node');
         $default = Hash::get($fieldInfo, 'default');
+        $fieldClass = Hash::get($fieldInfo, 'field');
+        $field = new $fieldClass;
 
         $dataDelimiter = Plugin::$plugin->service->getConfig('dataDelimiter');
 
@@ -77,7 +80,14 @@ class DataHelper
 
                     $value = array_merge($value, $delimitedValues);
                 } else {
-                    $value[] = $nodeValue;
+                    // special provision for when actual $nodeValue was empty,
+                    // so it was overwritten by the $default value that comes from a BaseRelationField
+                    // e.g. specifying a default asset to fall back on
+                    if (is_array($nodeValue) && $field instanceof BaseRelationField) {
+                        $value['elementIds'] = $nodeValue;
+                    } else {
+                        $value[] = $nodeValue;
+                    }
                 }
             }
         }

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -9,7 +9,6 @@ use craft\feedme\models\FeedModel;
 use craft\feedme\Plugin;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
-use DateTime;
 use Throwable;
 
 class DataHelper
@@ -220,7 +219,7 @@ class DataHelper
             if ($existingValue instanceof \DateTime || DateTimeHelper::isIso8601($existingValue)) {
                 $existingValue = Db::prepareDateForDb($existingValue);
             }
-            
+
             // If date value, make sure to cast it as a string to compare
             if ($newValue instanceof \DateTime || DateTimeHelper::isIso8601($newValue)) {
                 $newValue = Db::prepareDateForDb($newValue);
@@ -239,7 +238,7 @@ class DataHelper
 
             // Then check for simple attributes
             $existingValue = Hash::get($attributes, $key);
-            
+
             // If date value, make sure to cast it as a string to compare
             if ($existingValue instanceof \DateTime || DateTimeHelper::isIso8601($existingValue)) {
                 $existingValue = Db::prepareDateForDb($existingValue);

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -98,7 +98,6 @@ class DataHelper
         }
 
         return $default;
-
     }
 
     /**


### PR DESCRIPTION
### Description
If you map the assets field to a value from a feed, have an empty value in your data feed, and still select a default value, the import will throw the `preg_match` error. 
For other relational fields, the default value was ignored.
The default value was ignored if mapping by a label for multi-select and checkbox fields.

This PR ensures that the default value is applied if you map your field to an empty value and specify a default. It applies to all relational fields. 

It also ensures that multi-select and checkbox defaults are applied if you have mapped those fields by a label.

This can be applied to both v4 and v5 of the plugin.


### Related issues
#1195 
#1106 
#1154 
