### PR TITLE
allow user element full name mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added a feed setting that allows feeds to specify if they'd like empty values to used to overwrite existing data. ([#1228](https://github.com/craftcms/feed-me/pull/1228), [#797](https://github.com/craftcms/feed-me/issues/797), [#723](https://github.com/craftcms/feed-me/issues/723), [#854](https://github.com/craftcms/feed-me/issues/854), [#680](https://github.com/craftcms/feed-me/issues/680))
+- Add the ability to map the Full name for a feed to a User element which takes priority over the First and Last names. ([#1235](https://github.com/craftcms/feed-me/pull/1235))
 
 ### Changed
 - The `EVENT_AFTER_PARSE_ATTRIBUTE` event now allows plugins to modify parsed values.

--- a/src/templates/_includes/elements/user/map.html
+++ b/src/templates/_includes/elements/user/map.html
@@ -8,6 +8,13 @@
         type: 'text',
     },
 }, {
+    name: 'Full Name',
+    handle: 'fullName',
+    instructions: 'If you map the full name it will take priority over the first name and last name mappings.'|t('feed-me'),
+    default: {
+        type: 'text',
+    },
+}, {
     name: 'First Name',
     handle: 'firstName',
     default: {


### PR DESCRIPTION
### Description
Add the ability to map the Full Name for the user element. 

Currently, it’s only possible to map the First Name and Last Name, but Craft 4 uses the Full Name. 

Support for First Name and Last Name stays as is with this PR, but if you map the Full Name, it will take priority over First and Last Names.


### Related issues
#1152 
