### PR TITLE
Fix comparing empty arrays

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -334,6 +334,11 @@ class DataHelper
      */
     private static function _compareSimpleValues($fields, $key, $firstValue, $secondValue): bool
     {
+        // When the values are empty arrays we do NOT use the Hash::check below because that will always return false
+        if (is_array($firstValue) && is_array($secondValue) && count($firstValue) === 0 && count($secondValue) === 0) {
+            return true;
+        }
+        
         /** @noinspection TypeUnsafeComparisonInspection */
         // Should probably do a strict check, but doing this for backwards compatibility.
         if (Hash::check($fields, $key) && ($firstValue == $secondValue)) {


### PR DESCRIPTION
When the values are empty arrays we do NOT use Hash::check because that will always return false, hence even when both values are empty arrays the result will still be that the values are different and have to be imported

Fixes #1238 