### PR TITLE
Fix comparing arrays with entity references

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -334,6 +334,20 @@ class DataHelper
      */
     private static function _compareSimpleValues($fields, $key, $firstValue, $secondValue): bool
     {
+        // When the values are arrays filled with numbers then they most likely represent references to elements.
+        // Unfortunately these arrays sometimes have non-matching keys, while the values are the same, i.e. reference
+        // the same elements.  In this case, we should determine that the values are the same.
+        if (Hash::check($fields, $key)
+            && is_array($firstValue)
+            && is_array($secondValue)
+            && array_reduce($firstValue, static fn($carry, $item) => $carry && is_numeric($item), true)
+            && array_reduce($secondValue, static fn($carry, $item) => $carry && is_numeric($item), true)
+            && array_values($firstValue) == array_values($secondValue)
+        )
+        {
+            return true;
+        }        
+        
         /** @noinspection TypeUnsafeComparisonInspection */
         // Should probably do a strict check, but doing this for backwards compatibility.
         if (Hash::check($fields, $key) && ($firstValue == $secondValue)) {

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -345,8 +345,8 @@ class DataHelper
             && array_values($firstValue) == array_values($secondValue)
         ) {
             return true;
-        }        
-        
+        }
+
         /** @noinspection TypeUnsafeComparisonInspection */
         // Should probably do a strict check, but doing this for backwards compatibility.
         if (Hash::check($fields, $key) && ($firstValue == $secondValue)) {

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -343,8 +343,7 @@ class DataHelper
             && array_reduce($firstValue, static fn($carry, $item) => $carry && is_numeric($item), true)
             && array_reduce($secondValue, static fn($carry, $item) => $carry && is_numeric($item), true)
             && array_values($firstValue) == array_values($secondValue)
-        )
-        {
+        ) {
             return true;
         }        
         


### PR DESCRIPTION
When the values are empty arrays we do NOT use Hash::check because that will always return false, hence even when both values are empty arrays the result will still be that the values are different and have to be imported

Fixes #1238 