### PR TITLE
Bugfix/1154 parent mapping improvements

### DIFF
--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -152,6 +152,11 @@ class Category extends Element
             $query->siteId($this->feed['siteId']);
         }
 
+        // fix for https://github.com/craftcms/feed-me/issues/1154#issuecomment-1429622276
+        if (!empty($this->element->groupId)) {
+            $query->groupId($this->element->groupId);
+        }
+
         $element = $query->one();
 
         if ($element) {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -193,6 +193,11 @@ class Entry extends Element
             $query->siteId($this->feed['siteId']);
         }
 
+        // fix for https://github.com/craftcms/feed-me/issues/1154#issuecomment-1429622276
+        if (!empty($this->element->sectionId)) {
+            $query->sectionId($this->element->sectionId);
+        }
+
         $element = $query->one();
 
         if ($element) {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -217,6 +217,7 @@ class Entry extends Element
                 Plugin::error('Entry error: Could not create parent - `{e}`.', ['e' => json_encode($element->getErrors())]);
             } else {
                 Plugin::info('Entry `#{id}` added.', ['id' => $element->id]);
+                $this->element->newParentId = $element->id;
             }
 
             return $element->id;

--- a/src/templates/_includes/elements/categories/map.html
+++ b/src/templates/_includes/elements/categories/map.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% set categories = [{ label: 'Don’t import'|t('feed-me'), value: '' }] %}
-{% for category in craft.categories.all() %}
+{% for category in craft.categories({ groupId: groupId }).all() %}
     {% set categories = categories|merge([{ label: category.title|slice(0, 40), value: category.id }]) %}
 {% endfor %}
 


### PR DESCRIPTION
### Description
**Problem 1:**
- I have 2 sections: `section1` and `section2`,
- in the `section1` section, I have:
  - entry with title: “Year 1”; slug: “year-1”
  - subentry with title “Competition 1”; slug “competition-1”
  - subentry with title “Competition 2”; slug “competition-2”
- in the `section2` section, I have:
  - entry with title: “Year 1”; slug: “year-1”
  - subentry with title “Competition 1”; slug “competition-1”
  - subentry with title “Competition 2”; slug “competition-2”
- section 1 feed maps title, doesn’t map the slug, maps the parent based on “Title” and has “Create entries if they do not exist” checked
- if I run the section 1 feed once section 2 data is in, I get the `There was a problem getting the parent element. - Structures.php: 315` error.

**Fix:** This happens because searching for a parent is not limited to the entries section or category group we’re importing to. The fix is to limit searching for an existing parent within the section/group we’re importing to.


**Problem 2:**
- have an entry feed that maps the title and the parent and has “Create entries if they do not exist” checked
- data to import is:
```
{
	"entries": [
		{
			"name": "Competition 3",
			"parent": "Year 3"
		},
		{
			"name": "Competition 4",
			"parent": "Year 3"
		}
	]
}
```
- “Year 3” entry doesn’t exist - meaning it will be created on import
- parent entry is created correctly, but it’s not assigned to the element that triggered its creation - “Competition 3” in this case. It is assigned correctly to further elements, like “Competition 4”

**Fix:** Fixed by ensuring the `newParentId` has a value of the newly created entry assigned to it.


**Problem 3:**
It was possible to select a default parent for a category import from any group.

**Fix:** Limit categories showing in the Default value column for Parent to just the group we’re importing to.

### Related issues
#1154 
