### PR TITLE
Fixed compatibility with Google Maps plugin v4.3+

### DIFF
--- a/src/fields/GoogleMaps.php
+++ b/src/fields/GoogleMaps.php
@@ -3,6 +3,7 @@
 namespace craft\feedme\fields;
 
 use Cake\Utility\Hash;
+use Craft;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\DataHelper;
@@ -34,6 +35,26 @@ class GoogleMaps extends Field implements FieldInterface
      */
     public function getMappingTemplate(): string
     {
+        // By default, assume a modern version
+        $pre43 = false;
+
+        // Get plugins service
+        $plugins = Craft::$app->getPlugins();
+
+        // If the Google Maps plugin is installed & enabled
+        if ($plugins->isPluginEnabled('google-maps')) {
+            // Get info for Google Maps plugin
+            $info = $plugins->getPluginInfo('google-maps');
+            // Whether Google Maps plugin version is earlier than 4.3
+            $pre43 = (version_compare($info['version'], '4.3', '<'));
+        }
+
+        // If earlier than Google Maps v4.3, return old version of the template
+        if ($pre43) {
+            return 'feed-me/_includes/fields/google-maps-before-4-3';
+        }
+
+        // By default, return the modern version of the template
         return 'feed-me/_includes/fields/google-maps';
     }
 

--- a/src/templates/_includes/fields/google-maps-before-4-3.html
+++ b/src/templates/_includes/fields/google-maps-before-4-3.html
@@ -37,27 +37,18 @@
 </tr>
 
 {# Get comprehensive list of subfields, including coordinates #}
-{% set subfieldConfig = field.settings.subfieldConfig | merge([
-    {
-        'handle': 'lat',
-        'label': 'Latitude'
-    },
-    {
-        'handle': 'lng',
-        'label': 'Longitude'
-    },
-    {
-        'handle': 'zoom',
-        'label': 'Zoom'
-    },
-]) %}
+{% set subfieldConfig = field.settings.subfieldConfig | merge({
+    'lat': {'label': 'Latitude'},
+    'lng': {'label': 'Longitude'},
+    'zoom': {'label': 'Zoom'},
+}) %}
 
 {# Loop through all subfields #}
-{% for subfield in subfieldConfig %}
+{% for key,subfield in subfieldConfig %}
     {% set nameLabel = subfield['label'] %}
-    {% set instructionsHandle = handle ~ '[' ~ subfield['handle'] ~ ']' %}
+    {% set instructionsHandle = handle ~ '[' ~ key ~ ']' %}
 
-    {% set path = prefixPath|merge ([ 'fields', subfield['handle'] ]) %}
+    {% set path = prefixPath|merge ([ 'fields', key ]) %}
 
     {% set default = default ?? {
         type: 'text',


### PR DESCRIPTION
### Description

Patches a compatibility issue with the Google Maps plugin (if using GM v4.3+).

> NOTE: If patching an existing feed, it may be necessary to **remap the Address subfields**.

### Related issues

https://github.com/doublesecretagency/craft-googlemaps/issues/78