### PR TITLE
don't disable already disabled elements

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -201,8 +201,10 @@ abstract class Element extends Component implements ElementInterface
         foreach ($elementIds as $elementId) {
             /** @var BaseElement $element */
             $element = $elementsService->getElementById($elementId, $class);
-            $element->enabled = false;
-            $elementsService->saveElement($element, true, true, Hash::get($this->feed, 'updateSearchIndexes'));
+            if ($element->enabled) {
+                $element->enabled = false;
+                $elementsService->saveElement($element, true, true, Hash::get($this->feed, 'updateSearchIndexes'));
+            }
         }
 
         return true;
@@ -226,8 +228,10 @@ abstract class Element extends Component implements ElementInterface
 
         foreach ($query->each() as $element) {
             /** @var BaseElement $element */
-            $element->enabledForSite = false;
-            $elementsService->saveElement($element, false, false, Hash::get($this->feed, 'updateSearchIndexes'));
+            if ($element->enabledForSite) {
+                $element->enabledForSite = false;
+                $elementsService->saveElement($element, false, false, Hash::get($this->feed, 'updateSearchIndexes'));
+            }
         }
 
         return true;


### PR DESCRIPTION
### Description
If an element is already disabled (globally or for the site), don’t disable it again and don't trigger an unnecessary resave.

A copy of: https://github.com/craftcms/feed-me/pull/736 + additional safeguard for `disableForSite()`.

### Related issues
#1241 
