### PR TITLE
Bugfix/1154 adjusted fix for new parent

### DIFF
--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -185,7 +185,7 @@ class Category extends Element
         // use the default value if it's provided and none of the above worked
         // https://github.com/craftcms/feed-me/issues/1154
         if (!empty($default)) {
-            $this->element->newParentId = $default[0];
+            $this->element->parentId = $default[0];
 
             return $default[0];
         }

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -234,7 +234,7 @@ class Entry extends Element
         // use the default value if it's provided and none of the above worked
         // https://github.com/craftcms/feed-me/issues/1154
         if (!empty($default)) {
-            $this->element->newParentId = $default[0];
+            $this->element->parentId = $default[0];
 
             return $default[0];
         }

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -225,7 +225,7 @@ class Entry extends Element
                 Plugin::error('Entry error: Could not create parent - `{e}`.', ['e' => Json::encode($element->getErrors())]);
             } else {
                 Plugin::info('Entry `#{id}` added.', ['id' => $element->id]);
-                $this->element->newParentId = $element->id;
+                $this->element->parentId = $element->id;
             }
 
             return $element->id;


### PR DESCRIPTION
### Description
Craft 4 entry and category elements no longer have `newParentId` parameter, so changes from PR 1240 need to be adjusted for Feed Me v5 with this PR


### Related issues
#1154 
