### PR TITLE
make sure empty value is changed to an array

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -96,8 +96,12 @@ class DataHelper
     {
         $default = Hash::get($fieldInfo, 'default');
 
-        if (!empty($default) && !is_array($default)) {
-            $default = [$default];
+        if (!is_array($default)) {
+            if (empty($default)) {
+                $default = [];
+            } else {
+                $default = [$default];
+            }
         }
 
         return $default;


### PR DESCRIPTION
### Description
Allowing empty values works great, except it was freaking out for Checkbox and Multi Select fields which expect an array value, not a string. Added new safeguard to change an empty string to an empty array before `in_array` checks for those fields.


### Related issues
PR #1228
