### PR TITLE
Feature/add money field support

### DIFF
--- a/src/fields/Money.php
+++ b/src/fields/Money.php
@@ -51,7 +51,7 @@ class Money extends Field implements FieldInterface
         }
 
         return [
-            'value' => $value
+            'value' => $value,
         ];
     }
 }

--- a/src/fields/Money.php
+++ b/src/fields/Money.php
@@ -46,6 +46,10 @@ class Money extends Field implements FieldInterface
     {
         $value = $this->fetchValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         return [
             'value' => $value
         ];

--- a/src/fields/Money.php
+++ b/src/fields/Money.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace craft\feedme\fields;
+
+use craft\feedme\base\Field;
+use craft\feedme\base\FieldInterface;
+use craft\fields\Money as MoneyField;
+
+/**
+ *
+ * @property-read string $mappingTemplate
+ */
+class Money extends Field implements FieldInterface
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public static string $name = 'Money';
+
+    /**
+     * @var string
+     */
+    public static string $class = MoneyField::class;
+
+    // Templates
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public function getMappingTemplate(): string
+    {
+        return 'feed-me/_includes/fields/default';
+    }
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public function parseField(): mixed
+    {
+        $value = $this->fetchValue();
+
+        return [
+            'value' => $value
+        ];
+    }
+}

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -27,6 +27,7 @@ use craft\feedme\fields\Lightswitch;
 use craft\feedme\fields\Linkit;
 use craft\feedme\fields\Matrix;
 use craft\feedme\fields\MissingField;
+use craft\feedme\fields\Money;
 use craft\feedme\fields\MultiSelect;
 use craft\feedme\fields\Number;
 use craft\feedme\fields\RadioButtons;
@@ -133,6 +134,7 @@ class Fields extends Component
                 Matrix::class,
                 MultiSelect::class,
                 Number::class,
+                Money::class,
                 RadioButtons::class,
                 Table::class,
                 Tags::class,


### PR DESCRIPTION
### Description
Adds support for importing into the Money field.

Documentation: https://docs.craftcms.com/feed-me/v4/content-mapping/field-types.html should be updated to reference the Money field too. The same value is accepted as for the Number field (a single, numerical value).

