### PR TITLE
fixed type-o after webpack conversion

### DIFF
--- a/src/web/assets/feedme/FeedMeAsset.php
+++ b/src/web/assets/feedme/FeedMeAsset.php
@@ -26,7 +26,7 @@ class FeedMeAsset extends AssetBundle
         ];
 
         $this->js = [
-            'Feedme.js',
+            'FeedMe.js',
         ];
 
         $this->css = [


### PR DESCRIPTION
### Description
Fixed a type-o after webpack conversion. Applies to both v4 and v5 of the plugin.


### Related issues
#1257 
#1258 
#1259 
