### PR TITLE
Fixed a typo which rendered Show details button unusable

### DIFF
--- a/src/web/assets/feedme/FeedMeAsset.php
+++ b/src/web/assets/feedme/FeedMeAsset.php
@@ -26,7 +26,7 @@ class FeedMeAsset extends AssetBundle
         ];
 
         $this->js = [
-            'Feedme.js',
+            'FeedMe.js',
         ];
 
         $this->css = [


### PR DESCRIPTION
### Description

The asset filename is FeedMe.js, while Feedme.js was registered. 

