### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd /path/to/my-project.test
 composer require craftcms/feed-me
 
 # tell Craft to install the plugin
-./craft install/plugin feed-me
+./craft plugin/install feed-me
 ```
 
 ## Resources


### PR DESCRIPTION

### Description

Fix plugin install command as install/plugin is deprecated.

```
➜  craft ./craft install/plugin feed-me



    The install/plugin command is deprecated.
        Running plugin/install instead...

```
