### PR TITLE
Feature/797 empty string values and defaults

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -10,6 +10,7 @@ use craft\elements\Asset as AssetElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
 use craft\feedme\helpers\AssetHelper;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 use craft\helpers\Db;
 use craft\helpers\Json;
@@ -62,6 +63,17 @@ class Assets extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        // if the mapped value is not set in the feed
+        if ($value === null) {
+            return null;
+        }
+
+        // if value from the feed is empty and default is not set
+        // return an empty array; no point bothering further
+        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+            return [];
+        }
+
         $settings = Hash::get($this->field, 'settings');
         $folders = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
@@ -99,10 +111,6 @@ class Assets extends Field implements FieldInterface
         $urlsToUpload = [];
         $base64ToUpload = [];
 
-        if (!$value) {
-            return $foundElements;
-        }
-
         foreach ($value as $key => $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
             if (empty($dataValue) && empty($default)) {
@@ -117,7 +125,7 @@ class Assets extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (empty($dataValue)) {
+            if (trim($dataValue) === '') {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/Checkboxes.php
+++ b/src/fields/Checkboxes.php
@@ -47,6 +47,10 @@ class Checkboxes extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         $preppedData = [];
 
         $options = Hash::get($this->field, 'settings.options');

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -7,6 +7,7 @@ use Craft;
 use craft\commerce\elements\Product as ProductElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 use craft\helpers\Db;
 
@@ -56,6 +57,17 @@ class CommerceProducts extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        // if the mapped value is not set in the feed
+        if ($value === null) {
+            return null;
+        }
+
+        // if value from the feed is empty and default is not set
+        // return an empty array; no point bothering further
+        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+            return [];
+        }
+
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
@@ -67,7 +79,7 @@ class CommerceProducts extends Field implements FieldInterface
 
         if (is_array($sources)) {
             foreach ($sources as $source) {
-                list(, $uid) = explode(':', $source);
+                [, $uid] = explode(':', $source);
                 $typeIds[] = Db::idByUid('{{%commerce_producttypes}}', $uid);
             }
         } elseif ($sources === '*') {
@@ -75,10 +87,6 @@ class CommerceProducts extends Field implements FieldInterface
         }
 
         $foundElements = [];
-
-        if (!$value) {
-            return $foundElements;
-        }
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
@@ -94,7 +102,7 @@ class CommerceProducts extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (empty($dataValue)) {
+            if (trim($dataValue) === '') {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -7,6 +7,7 @@ use Craft;
 use craft\commerce\elements\Variant as VariantElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 
 /**
@@ -55,6 +56,17 @@ class CommerceVariants extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        // if the mapped value is not set in the feed
+        if ($value === null) {
+            return null;
+        }
+
+        // if value from the feed is empty and default is not set
+        // return an empty array; no point bothering further
+        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+            return [];
+        }
+
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
@@ -66,7 +78,7 @@ class CommerceVariants extends Field implements FieldInterface
 
         if (is_array($sources)) {
             foreach ($sources as $source) {
-                list(, $uid) = explode(':', $source);
+                [, $uid] = explode(':', $source);
                 $typeIds[] = $uid;
             }
         } elseif ($sources === '*') {
@@ -74,10 +86,6 @@ class CommerceVariants extends Field implements FieldInterface
         }
 
         $foundElements = [];
-
-        if (!$value) {
-            return $foundElements;
-        }
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
@@ -93,7 +101,7 @@ class CommerceVariants extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (empty($dataValue)) {
+            if (trim($dataValue) === '') {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/Date.php
+++ b/src/fields/Date.php
@@ -47,6 +47,10 @@ class Date extends Field implements FieldInterface
     {
         $value = $this->fetchValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         $formatting = Hash::get($this->fieldInfo, 'options.match');
 
         $dateValue = DateHelper::parseString($value, $formatting);

--- a/src/fields/DefaultField.php
+++ b/src/fields/DefaultField.php
@@ -45,6 +45,10 @@ class DefaultField extends Field implements FieldInterface
     {
         $value = $this->fetchValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         // Default fields expect strings, if its an array for an odd reason, serialise it
         if (is_array($value)) {
             if (empty($value)) {

--- a/src/fields/Dropdown.php
+++ b/src/fields/Dropdown.php
@@ -52,12 +52,16 @@ class Dropdown extends Field implements FieldInterface
         }
 
         $value = (string) $value;
+        $default = Hash::get($this->fieldInfo, 'default');
 
         $options = Hash::get($this->field, 'settings.options');
         $match = Hash::get($this->fieldInfo, 'options.match', 'value');
 
         foreach ($options as $option) {
-            if (isset($option['value']) && $value === $option[$match]) {
+            if (
+                (isset($option['value']) && $value === $option[$match]) ||
+                ($match === 'label' && $value === $default && $value === $option['value'])
+            ) {
                 return $option['value'];
             }
         }

--- a/src/fields/Dropdown.php
+++ b/src/fields/Dropdown.php
@@ -47,6 +47,12 @@ class Dropdown extends Field implements FieldInterface
     {
         $value = $this->fetchValue();
 
+        if ($value === null) {
+            return null;
+        }
+
+        $value = (string) $value;
+
         $options = Hash::get($this->field, 'settings.options');
         $match = Hash::get($this->fieldInfo, 'options.match', 'value');
 
@@ -56,14 +62,10 @@ class Dropdown extends Field implements FieldInterface
             }
         }
 
-        return null;
-    }
+        if (empty($value)) {
+            return $value;
+        }
 
-    /**
-     * @inheritDoc
-     */
-    public function fetchValue()
-    {
-        return (string) parent::fetchValue();
+        return null;
     }
 }

--- a/src/fields/GoogleMaps.php
+++ b/src/fields/GoogleMaps.php
@@ -54,7 +54,10 @@ class GoogleMaps extends Field implements FieldInterface
         }
 
         foreach ($fields as $subFieldHandle => $subFieldInfo) {
-            $preppedData[$subFieldHandle] = DataHelper::fetchValue($this->feedData, $subFieldInfo, $this->feed);
+            $value = DataHelper::fetchValue($this->feedData, $subFieldInfo, $this->feed);
+            if ($value !== null) {
+                $preppedData[$subFieldHandle] = $value;
+            }
         }
 
         // Protect against sending an empty array

--- a/src/fields/Lightswitch.php
+++ b/src/fields/Lightswitch.php
@@ -46,6 +46,10 @@ class Lightswitch extends Field implements FieldInterface
     {
         $value = $this->fetchValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         return $this->parseValue($value);
     }
 

--- a/src/fields/Linkit.php
+++ b/src/fields/Linkit.php
@@ -58,6 +58,14 @@ class Linkit extends Field implements FieldInterface
             $preppedData[$subFieldHandle] = DataHelper::fetchValue($this->feedData, $subFieldInfo, $this->feed);
         }
 
+        if (empty(
+            array_filter($preppedData, function($val) {
+                return $val !== null;
+            })
+        )) {
+            return null;
+        }
+
         if ($preppedData) {
             // Handle Link Type
             $preppedData['type'] = empty($preppedData['type'] ?? '') ? 'presseddigital\linkit\models\Url' : $preppedData['type'];

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -134,6 +134,9 @@ class Matrix extends Field implements FieldInterface
 
         // $order = 0;
 
+        // check if all values in fieldData are empty strings
+        $allEmpty = true;
+
         // New, we've got a collection of prepared data, but its formatted a little rough, due to catering for
         // sub-field data that could be arrays or single values. Lets build our Matrix-ready data
         foreach ($fieldData as $blockSubFieldHandle => $value) {
@@ -151,11 +154,29 @@ class Matrix extends Field implements FieldInterface
             $preppedData[$blockIndex . '.enabled'] = !$disabled;
             $preppedData[$blockIndex . '.collapsed'] = $collapsed;
             $preppedData[$blockIndex . '.fields.' . $subFieldHandle] = $value;
+
+            if (is_string($value) && !empty($value)) {
+                $allEmpty = false;
+            }
+            if (is_array($value) && !empty(array_filter($value))) {
+                $allEmpty = false;
+            }
             // $order++;
         }
 
         $preppedData = Hash::expand($preppedData);
 
+        // if there's nothing in the prepped data, return null, as if mapping doesn't exist
+        if (empty($preppedData)) {
+            return null;
+        }
+
+        // if everything in the $preppedData[][fields] is empty - return empty array
+        if ($allEmpty === true) {
+            return [];
+        }
+
+        // otherwise return what we have
         return $preppedData;
     }
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -155,16 +155,12 @@ class Matrix extends Field implements FieldInterface
             $preppedData[$blockIndex . '.collapsed'] = $collapsed;
             $preppedData[$blockIndex . '.fields.' . $subFieldHandle] = $value;
 
-            if (is_string($value) && !empty($value)) {
+            if ((is_string($value) && !empty($value)) || (is_array($value) && !empty(array_filter($value)))) {
                 $allEmpty = false;
             }
-            if (is_array($value) && !empty(array_filter($value))) {
-                $allEmpty = false;
-            }
+
             // $order++;
         }
-
-        $preppedData = Hash::expand($preppedData);
 
         // if there's nothing in the prepped data, return null, as if mapping doesn't exist
         if (empty($preppedData)) {
@@ -175,6 +171,8 @@ class Matrix extends Field implements FieldInterface
         if ($allEmpty === true) {
             return [];
         }
+
+        $preppedData = Hash::expand($preppedData);
 
         // otherwise return what we have
         return $preppedData;

--- a/src/fields/MultiSelect.php
+++ b/src/fields/MultiSelect.php
@@ -47,6 +47,10 @@ class MultiSelect extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         $preppedData = [];
 
         $options = Hash::get($this->field, 'settings.options');

--- a/src/fields/Number.php
+++ b/src/fields/Number.php
@@ -46,6 +46,10 @@ class Number extends Field implements FieldInterface
     {
         $value = $this->fetchValue();
 
+        if ($value === null) {
+            return null;
+        }
+
         return $this->parseValue($value);
     }
 

--- a/src/fields/RadioButtons.php
+++ b/src/fields/RadioButtons.php
@@ -57,6 +57,10 @@ class RadioButtons extends Field implements FieldInterface
             }
         }
 
+        if (empty($value)) {
+            return $value;
+        }
+
         return null;
     }
 }

--- a/src/fields/RadioButtons.php
+++ b/src/fields/RadioButtons.php
@@ -47,12 +47,16 @@ class RadioButtons extends Field implements FieldInterface
     public function parseField()
     {
         $value = $this->fetchValue();
+        $default = Hash::get($this->fieldInfo, 'default');
 
         $options = Hash::get($this->field, 'settings.options');
         $match = Hash::get($this->fieldInfo, 'options.match', 'value');
 
         foreach ($options as $option) {
-            if ($value === $option[$match]) {
+            if (
+                (isset($option['value']) && $value === $option[$match]) ||
+                ($match === 'label' && $value === $default && $value === $option['value'])
+            ) {
                 return $option['value'];
             }
         }

--- a/src/fields/SmartMap.php
+++ b/src/fields/SmartMap.php
@@ -54,7 +54,10 @@ class SmartMap extends Field implements FieldInterface
         }
 
         foreach ($fields as $subFieldHandle => $subFieldInfo) {
-            $preppedData[$subFieldHandle] = DataHelper::fetchValue($this->feedData, $subFieldInfo, $this->feed);
+            $value = DataHelper::fetchValue($this->feedData, $subFieldInfo, $this->feed);
+            if ($value !== null) {
+                $preppedData[$subFieldHandle] = $value;
+            }
         }
 
         // Protect against sending an empty array

--- a/src/fields/SuperTable.php
+++ b/src/fields/SuperTable.php
@@ -131,6 +131,9 @@ class SuperTable extends Field implements FieldInterface
 
         $order = 0;
 
+        // check if all values in fieldData are empty strings
+        $allEmpty = true;
+
         // New, we've got a collection of prepared data, but its formatted a little rough, due to catering for
         // sub-field data that could be arrays or single values. Lets build our Matrix-ready data
         foreach ($fieldData as $blockSubFieldHandle => $value) {
@@ -144,7 +147,21 @@ class SuperTable extends Field implements FieldInterface
             $preppedData[$blockIndex . '.enabled'] = true;
             $preppedData[$blockIndex . '.fields.' . $subFieldHandle] = $value;
 
+            if ((is_string($value) && !empty($value)) || (is_array($value) && !empty(array_filter($value)))) {
+                $allEmpty = false;
+            }
+
             $order++;
+        }
+
+        // if there's nothing in the prepped data, return null, as if mapping doesn't exist
+        if (empty($preppedData)) {
+            return null;
+        }
+
+        // if everything in the $preppedData[][fields] is empty - return empty array
+        if ($allEmpty === true) {
+            return [];
         }
 
         $preppedData = Hash::expand($preppedData);

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -8,6 +8,7 @@ use craft\base\Element as BaseElement;
 use craft\elements\Tag as TagElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 use craft\helpers\Db;
 
@@ -58,6 +59,17 @@ class Tags extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        // if the mapped value is not set in the feed
+        if ($value === null) {
+            return null;
+        }
+
+        // if value from the feed is empty and default is not set
+        // return an empty array; no point bothering further
+        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+            return [];
+        }
+
         $source = Hash::get($this->field, 'settings.source');
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
@@ -68,14 +80,10 @@ class Tags extends Field implements FieldInterface
         $node = Hash::get($this->fieldInfo, 'node');
 
         // Get tag group id
-        list(, $groupUid) = explode(':', $source);
+        [, $groupUid] = explode(':', $source);
         $groupId = Db::idByUid('{{%taggroups}}', $groupUid);
 
         $foundElements = [];
-
-        if (!$value) {
-            return $foundElements;
-        }
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
@@ -91,7 +99,7 @@ class Tags extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (empty($dataValue)) {
+            if (trim($dataValue) === '') {
                 $foundElements = $default;
                 break;
             }

--- a/src/fields/TypedLink.php
+++ b/src/fields/TypedLink.php
@@ -57,6 +57,14 @@ class TypedLink extends Field implements FieldInterface
             $preppedData[$subFieldHandle] = DataHelper::fetchValue($this->feedData, $subFieldInfo, $this->feed);
         }
 
+        if (empty(
+        array_filter($preppedData, function($val) {
+            return $val !== null;
+        })
+        )) {
+            return null;
+        }
+
         // Protect against sending an empty array
         if (!$preppedData) {
             return null;

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -8,6 +8,7 @@ use craft\base\Element as BaseElement;
 use craft\elements\User as UserElement;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 use craft\helpers\Db;
 
@@ -58,6 +59,17 @@ class Users extends Field implements FieldInterface
         $value = $this->fetchArrayValue();
         $default = $this->fetchDefaultArrayValue();
 
+        // if the mapped value is not set in the feed
+        if ($value === null) {
+            return null;
+        }
+
+        // if value from the feed is empty and default is not set
+        // return an empty array; no point bothering further
+        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+            return [];
+        }
+
         $sources = Hash::get($this->field, 'settings.sources');
         $limit = Hash::get($this->field, 'settings.limit');
         $match = Hash::get($this->fieldInfo, 'options.match', 'email');
@@ -70,7 +82,7 @@ class Users extends Field implements FieldInterface
 
         if (is_array($sources)) {
             foreach ($sources as $source) {
-                list(, $uid) = explode(':', $source);
+                [, $uid] = explode(':', $source);
                 $groupIds[] = Db::idByUid('{{%usergroups}}', $uid);
             }
         } elseif ($sources === '*') {
@@ -78,10 +90,6 @@ class Users extends Field implements FieldInterface
         }
 
         $foundElements = [];
-
-        if (!$value) {
-            return $foundElements;
-        }
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
@@ -97,7 +105,7 @@ class Users extends Field implements FieldInterface
 
             // special provision for falling back on default BaseRelationField value
             // https://github.com/craftcms/feed-me/issues/1195
-            if (empty($dataValue)) {
+            if (trim($dataValue) === '') {
                 $foundElements = $default;
                 break;
             }

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -22,7 +22,8 @@ class DataHelper
      * @param $value
      * @return bool
      */
-    public static function isArrayValueEmpty($value) {
+    public static function isArrayValueEmpty($value)
+    {
         return (!$value || (is_array($value) && empty(array_filter($value))));
     }
 

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -17,6 +17,16 @@ class DataHelper
     // =========================================================================
 
     /**
+     * Check if provided value is not set or empty or an array of empties
+     *
+     * @param $value
+     * @return bool
+     */
+    public static function isArrayValueEmpty($value) {
+        return (!$value || (is_array($value) && empty(array_filter($value))));
+    }
+
+    /**
      * @param $feedData
      * @param $fieldInfo
      * @return array|ArrayAccess|mixed|string|null
@@ -49,7 +59,7 @@ class DataHelper
      */
     public static function fetchArrayValue($feedData, $fieldInfo)
     {
-        $value = [];
+        $value = null;
 
         $node = Hash::get($fieldInfo, 'node');
 
@@ -120,7 +130,7 @@ class DataHelper
             $feed = $feed->toArray();
         }
 
-        $value = [];
+        $value = null;
 
         $node = Hash::get($fieldInfo, 'node');
         $default = Hash::get($fieldInfo, 'default');
@@ -137,7 +147,7 @@ class DataHelper
             $feedPath = preg_replace('/^(\d+\/)|(\/\d+)/', '', $feedPath);
 
             if ($feedPath == $node || $nodePath == $node) {
-                if ($nodeValue === null || $nodeValue === '') {
+                if ($nodeValue === null || ($feed !== null && $nodeValue === '' && $feed['setEmptyValues'])) {
                     $nodeValue = $default;
                 }
 
@@ -154,6 +164,10 @@ class DataHelper
                     $value[] = $nodeValue;
                 }
             }
+        }
+
+        if ($value === null) {
+            return null;
         }
 
         // Help to normalise things if an array with only one item. Probably a better idea to offload this to each

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -393,12 +393,10 @@ class Process extends Component
             if (Hash::get($fieldInfo, 'field')) {
                 $fieldValue = Plugin::$plugin->fields->parseField($feed, $element, $feedData, $fieldHandle, $fieldInfo);
 
-                if ($feed['setEmptyValues'] === 1 && $fieldValue === null) {
-                    $fieldData[$fieldHandle] = "";
-                }
-
                 if ($fieldValue !== null) {
-                    $fieldData[$fieldHandle] = $fieldValue;
+                    if ($feed['setEmptyValues'] === 1 || ($feed['setEmptyValues'] === 0 && !empty($fieldValue))) {
+                        $fieldData[$fieldHandle] = $fieldValue;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description
Adjustments for empty value vs no value and `setEmptyValues` and using defaults.

- If mapped values are defined in the feed and are empty and `setEmptyValues` is `on` - clear the existing values. 
- If mapped values are not defined in the feed, ignore them (don’t update existing values).
- If mapped values are defined in the feed and are empty, `setEmptyValues` is `on`, and defaults are mapped - use the defaults.
- If mapped values are defined in the feed and are empty, `setEmptyValues` is `on`, and defaults are mapped, ignore them (don’t update existing values).

@angrybrad - if you could please let me know once this is merged into `develop`, I would like to test it again, primarily because of the difference in handling matrix blocks.

### Related issues
https://github.com/craftcms/feed-me/issues/797#issuecomment-1476281368
