### PR TITLE
using default value shouldn't be linked to setEmptyValues

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -148,7 +148,7 @@ class DataHelper
             $feedPath = preg_replace('/^(\d+\/)|(\/\d+)/', '', $feedPath);
 
             if ($feedPath == $node || $nodePath == $node) {
-                if ($nodeValue === null || ($feed !== null && $nodeValue === '' && $feed['setEmptyValues'])) {
+                if ($nodeValue === null || $nodeValue === '') {
                     $nodeValue = $default;
                 }
 


### PR DESCRIPTION
### Description
Using default value shouldn’t be linked to `setEmptyValues`.

For v4 and v5.
