### PR TITLE
fix for matrix element inner fields using first set of data for all entries

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -144,11 +144,12 @@ abstract class Field extends Component
 
     /**
      * @param $elementIds
+     * @param null $nodeKey
      * @throws Throwable
      * @throws ElementNotFoundException
      * @throws Exception
      */
-    protected function populateElementFields($elementIds)
+    protected function populateElementFields($elementIds, $nodeKey = null)
     {
         $elementsService = Craft::$app->getElements();
         $fields = Hash::get($this->fieldInfo, 'fields');
@@ -166,7 +167,7 @@ abstract class Field extends Component
 
                 // Arrayed content doesn't provide defaults because its unable to determine how many items it _should_ return
                 // This also checks if there was any data that corresponds on the same array index/level as our element
-                $value = Hash::get($fieldValue, $key, $default);
+                $value = Hash::get($fieldValue, $nodeKey, $default);
 
                 if ($value) {
                     $fieldData[$elementId][$fieldHandle] = $value;
@@ -192,5 +193,26 @@ abstract class Field extends Component
 
             Plugin::info('`{handle}` - Processed {name} [`#{id}`]({url}) sub-fields with content: `{content}`.', ['name' => $element::displayName(), 'id' => $elementId, 'url' => $element->cpEditUrl, 'handle' => $this->fieldHandle, 'content' => json_encode($fieldContent)]);
         }
+    }
+
+    /**
+     * Get numerical node key from node name.
+     * E.g. if $nodeName is authors/1/author/name, the $nodeKey should be 1
+     *
+     * @param $nodeName
+     * @return mixed|null
+     */
+    protected function getArrayKeyFromNode($nodeName)
+    {
+        $nodeKey = null;
+
+        if (!empty($nodeName)) {
+            preg_match('/\/(\d+)\//', $nodeName, $matches);
+            if (isset($matches[1])) {
+                $nodeKey = $matches[1];
+            }
+        }
+
+        return $nodeKey;
     }
 }

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -83,6 +83,7 @@ class Assets extends Field implements FieldInterface
         $conflict = Hash::get($this->fieldInfo, 'options.conflict');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
+        $nodeKey = null;
 
         // Get folder id's for connecting
         $folderIds = $this->field->resolveDynamicPathToFolderId($this->element);
@@ -182,6 +183,8 @@ class Assets extends Field implements FieldInterface
                     Plugin::info('Skipping asset upload (already exists).');
                 }
             }
+
+            $nodeKey = $this->getArrayKeyFromNode($node);
         }
 
         if ($upload) {
@@ -203,7 +206,7 @@ class Assets extends Field implements FieldInterface
 
         // Check for any sub-fields for the element
         if ($fields) {
-            $this->populateElementFields($foundElements);
+            $this->populateElementFields($foundElements, $nodeKey);
         }
 
         $foundElements = array_unique($foundElements);

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -77,6 +77,7 @@ class Categories extends Field implements FieldInterface
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
+        $nodeKey = null;
 
         // Get source id's for connecting
         [, $groupUid] = explode(':', $source);
@@ -145,6 +146,8 @@ class Categories extends Field implements FieldInterface
             if ((count($ids) == 0) && $create && $match === 'title') {
                 $foundElements[] = $this->_createElement($dataValue, $groupId);
             }
+
+            $nodeKey = $this->getArrayKeyFromNode($node);
         }
 
         // Check for field limit - only return the specified amount
@@ -154,7 +157,7 @@ class Categories extends Field implements FieldInterface
 
         // Check for any sub-fields for the element
         if ($fields) {
-            $this->populateElementFields($foundElements);
+            $this->populateElementFields($foundElements, $nodeKey);
         }
 
         $foundElements = array_unique($foundElements);

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -77,6 +77,7 @@ class Entries extends Field implements FieldInterface
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
+        $nodeKey = null;
 
         $sectionIds = [];
 
@@ -160,6 +161,8 @@ class Entries extends Field implements FieldInterface
             if ((count($ids) == 0) && $create && $match === 'title') {
                 $foundElements[] = $this->_createElement($dataValue);
             }
+
+            $nodeKey = $this->getArrayKeyFromNode($node);
         }
 
         // Check for field limit - only return the specified amount
@@ -169,7 +172,7 @@ class Entries extends Field implements FieldInterface
 
         // Check for any sub-fields for the element
         if ($fields) {
-            $this->populateElementFields($foundElements);
+            $this->populateElementFields($foundElements, $nodeKey);
         }
 
         $foundElements = array_unique($foundElements);

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -123,10 +123,12 @@ class Matrix extends Field implements FieldInterface
 
             $parsedValue = $this->_parseSubField($nodePaths, $subFieldHandle, $subFieldInfo);
 
-            if (isset($fieldData[$key])) {
-                $fieldData[$key] = array_merge_recursive($fieldData[$key], $parsedValue);
-            } else {
-                $fieldData[$key] = $parsedValue;
+            if ($parsedValue !== null) {
+                if (isset($fieldData[$key])) {
+                    $fieldData[$key] = array_merge_recursive($fieldData[$key], $parsedValue);
+                } else {
+                    $fieldData[$key] = $parsedValue;
+                }
             }
         }
 

--- a/src/fields/Tags.php
+++ b/src/fields/Tags.php
@@ -78,6 +78,7 @@ class Tags extends Field implements FieldInterface
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
+        $nodeKey = null;
 
         // Get tag group id
         [, $groupUid] = explode(':', $source);
@@ -146,6 +147,8 @@ class Tags extends Field implements FieldInterface
             if ((count($ids) == 0) && $create && $match === 'title') {
                 $foundElements[] = $this->_createElement($dataValue, $groupId);
             }
+
+            $nodeKey = $this->getArrayKeyFromNode($node);
         }
 
         // Check for field limit - only return the specified amount
@@ -155,7 +158,7 @@ class Tags extends Field implements FieldInterface
 
         // Check for any sub-fields for the element
         if ($fields) {
-            $this->populateElementFields($foundElements);
+            $this->populateElementFields($foundElements, $nodeKey);
         }
 
         $foundElements = array_unique($foundElements);

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -76,6 +76,7 @@ class Users extends Field implements FieldInterface
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
+        $nodeKey = null;
 
         // Get source id's for connecting
         $groupIds = [];
@@ -140,6 +141,8 @@ class Users extends Field implements FieldInterface
             if ((count($ids) == 0) && $create && $match === 'email') {
                 $foundElements[] = $this->_createElement($dataValue, $groupIds);
             }
+
+            $nodeKey = $this->getArrayKeyFromNode($node);
         }
 
         // Check for field limit - only return the specified amount
@@ -149,7 +152,7 @@ class Users extends Field implements FieldInterface
 
         // Check for any sub-fields for the element
         if ($fields) {
-            $this->populateElementFields($foundElements);
+            $this->populateElementFields($foundElements, $nodeKey);
         }
 
         $foundElements = array_unique($foundElements);


### PR DESCRIPTION
### Description
This PR fixes en issue where: if you have a matrix field with e.g. entries field in it and for that entries field you want to map inner element fields, content from the first entry is used to populate all other entries.


### Related issues
#1227 
