### PR TITLE
different approach to importing default vals for matrix

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -5,6 +5,7 @@ namespace craft\feedme\fields;
 use Cake\Utility\Hash;
 use craft\feedme\base\Field;
 use craft\feedme\base\FieldInterface;
+use craft\feedme\helpers\DataHelper;
 use craft\feedme\Plugin;
 
 /**
@@ -61,6 +62,7 @@ class Matrix extends Field implements FieldInterface
         foreach ($this->feedData as $nodePath => $value) {
             // Get the field mapping info for this node in the feed
             $fieldInfo = $this->_getFieldMappingInfoForNodePath($nodePath, $blocks);
+            $nodePathSegments = explode('/', $nodePath);
 
             // If this is data concerning our Matrix field and blocks
             if ($fieldInfo) {
@@ -69,20 +71,8 @@ class Matrix extends Field implements FieldInterface
                 $subFieldInfo = $fieldInfo['subFieldInfo'];
                 $isComplexField = $fieldInfo['isComplexField'];
 
-                $nodePathSegments = explode('/', $nodePath);
-                $blockIndex = Hash::get($nodePathSegments, 1);
-
-                if (!is_numeric($blockIndex)) {
-                    // Try to check if its only one-level deep (only importing one block type)
-                    // which is particularly common for JSON.
-                    $blockIndex = Hash::get($nodePathSegments, 2);
-
-                    if (!is_numeric($blockIndex)) {
-                        $blockIndex = 0;
-                    }
-                }
-
-                $key = $blockIndex . '.' . $blockHandle . '.' . $subFieldHandle;
+                //$nodePathSegments = explode('/', $nodePath);
+                $key = $this->_getBlockKey($nodePathSegments, $blockHandle, $subFieldHandle);
 
                 // Check for complex fields (think Table, Super Table, etc), essentially anything that has
                 // sub-fields, and doesn't have data directly mapped to the field itself. It needs to be
@@ -106,6 +96,19 @@ class Matrix extends Field implements FieldInterface
                     $fieldData[$key] = is_array($parsedValue) ? array_merge_recursive($fieldData[$key], $parsedValue) : $fieldData[$key];
                 } else {
                     $fieldData[$key] = $parsedValue;
+                }
+            }
+
+            foreach ($blocks as $blockHandle => $fields) {
+                foreach ($fields['fields'] as $fieldHandle => $fieldInfo) {
+                    $node = Hash::get($fieldInfo, 'node');
+                    if ($node === 'usedefault') {
+                        $key = $this->_getBlockKey($nodePathSegments, $blockHandle, $fieldHandle);
+
+                        //$parsedValue = $this->_parseSubField($this->feedData, $fieldHandle, $feedInfo);
+                        $parsedValue = DataHelper::fetchSimpleValue($this->feedData, $fieldInfo);
+                        $fieldData[$key] = $parsedValue;
+                    }
                 }
             }
         }
@@ -185,9 +188,34 @@ class Matrix extends Field implements FieldInterface
     // =========================================================================
 
     /**
+     * Get block's key
+     *
+     * @param array $nodePathSegments
+     * @param string $blockHandle
+     * @param string $fieldHandle
+     * @return string
+     */
+    private function _getBlockKey(array $nodePathSegments, string $blockHandle, string $fieldHandle): string
+    {
+        $blockIndex = Hash::get($nodePathSegments, 1);
+
+        if (!is_numeric($blockIndex)) {
+            // Try to check if its only one-level deep (only importing one block type)
+            // which is particularly common for JSON.
+            $blockIndex = Hash::get($nodePathSegments, 2);
+
+            if (!is_numeric($blockIndex)) {
+                $blockIndex = 0;
+            }
+        }
+
+        return $blockIndex . '.' . $blockHandle . '.' . $fieldHandle;
+    }
+
+    /**
      * @param $nodePath
      * @param $blocks
-     * @return array|null
+     * @return array|null|string
      */
     private function _getFieldMappingInfoForNodePath($nodePath, $blocks)
     {
@@ -216,7 +244,7 @@ class Matrix extends Field implements FieldInterface
                     }
                 }
 
-                if ($feedPath == $node || $node === 'usedefault') {
+                if ($feedPath == $node) {
                     return [
                         'blockHandle' => $blockHandle,
                         'subFieldHandle' => $subFieldHandle,

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -71,7 +71,6 @@ class Matrix extends Field implements FieldInterface
                 $subFieldInfo = $fieldInfo['subFieldInfo'];
                 $isComplexField = $fieldInfo['isComplexField'];
 
-                //$nodePathSegments = explode('/', $nodePath);
                 $key = $this->_getBlockKey($nodePathSegments, $blockHandle, $subFieldHandle);
 
                 // Check for complex fields (think Table, Super Table, etc), essentially anything that has
@@ -105,7 +104,6 @@ class Matrix extends Field implements FieldInterface
                     if ($node === 'usedefault') {
                         $key = $this->_getBlockKey($nodePathSegments, $blockHandle, $fieldHandle);
 
-                        //$parsedValue = $this->_parseSubField($this->feedData, $fieldHandle, $feedInfo);
                         $parsedValue = DataHelper::fetchSimpleValue($this->feedData, $fieldInfo);
                         $fieldData[$key] = $parsedValue;
                     }


### PR DESCRIPTION
### Description
When importing values to Matrix blocks via “Use default value”, incorrect data was used.
E.g. default assets were not used, a wrong copy was imported, and so on.

This PR changes how “use default” for matrix blocks is processed.

Applies to v4 and v5.


### Related issues
#674
