### PR TITLE
remove collapsed option for matrix blocks

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -148,13 +148,11 @@ class Matrix extends Field implements FieldInterface
             $subFieldHandle = $handles[2];
 
             $disabled = Hash::get($this->fieldInfo, 'blocks.' . $blockHandle . '.disabled', false);
-            $collapsed = Hash::get($this->fieldInfo, 'blocks.' . $blockHandle . '.collapsed', false);
 
             // Prepare an array that's ready for Matrix to import it
             $preppedData[$blockIndex . '.type'] = $blockHandle;
             // $preppedData[$blockIndex . '.order'] = $order;
             $preppedData[$blockIndex . '.enabled'] = !$disabled;
-            $preppedData[$blockIndex . '.collapsed'] = $collapsed;
             $preppedData[$blockIndex . '.fields.' . $subFieldHandle] = $value;
 
             if ((is_string($value) && !empty($value)) || (is_array($value) && !empty(array_filter($value)))) {

--- a/src/templates/_includes/fields/matrix.html
+++ b/src/templates/_includes/fields/matrix.html
@@ -35,7 +35,6 @@
                     {% set blockPath = [ handle, 'blocks', blocktype.handle ] %}
 
                     {% set disabled = hash_get(feed.fieldMapping, blockPath|join('.') ~ '.disabled') ?: '' %}
-                    {% set collapsed = hash_get(feed.fieldMapping, blockPath|join('.') ~ '.collapsed') ?: '' %}
 
                     {% namespace 'fieldMapping[' ~ blockPath|join('][') ~ ']' %}
                         {{ feedMeMacro.checkbox({
@@ -43,13 +42,6 @@
                             name: 'disabled',
                             value: 1,
                             checked: disabled,
-                        }) }}
-
-                        {{ feedMeMacro.checkbox({
-                            label: 'Collapsed'|t('feed-me'),
-                            name: 'collapsed',
-                            value: 1,
-                            checked: collapsed,
                         }) }}
                     {% endnamespace %}
                 </div>


### PR DESCRIPTION
### Description
Removes the `collapsed` checkbox from the matrix block mapping screen. Collapsed data is stored in the local storage, not DB, so importing in via Feed Me is not an option.


### Related issues
#709 
