### PR TITLE
Adds recursive comparison when dealing with Matrix

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -254,6 +254,12 @@ class DataHelper
                 unset($trackedChanges[$key]);
                 continue;
             }
+            
+            // Check for complex fields
+            if (self::_compareComplexValues($fields, $key, $existingValue, $newValue)) {
+                unset($trackedChanges[$key]);
+                continue;
+            }
 
             // Then check for simple attributes
             $existingValue = Hash::get($attributes, $key);
@@ -378,6 +384,64 @@ class DataHelper
 
             // An array, but loosely equal
             return true;
+        }
+
+        // Didn't match
+        return false;
+    }
+    
+    /**
+     * Compare values recursively while ignoring property order and null values
+     *
+     * @param mixed $firstValue
+     * @param mixed $secondValue
+     * @return bool
+     */
+    private static function _recursiveCompare(mixed $firstValue, mixed $secondValue): bool
+    {
+        if (is_array($firstValue) && is_array($secondValue)) {
+            // Ignore values that are `null` or empty arrays
+            $firstValue = array_filter($firstValue, static fn (mixed $value) => !($value === null || $value === []));
+            $secondValue = array_filter($secondValue, static fn (mixed $value) => !($value === null || $value === []));
+
+            // Both values must have the same keys (ignoring order)
+            $firstKeys = array_keys($firstValue);
+            $secondKeys = array_keys($secondValue);
+            if (count(array_diff($firstKeys, $secondKeys)) || count(array_diff($secondKeys, $firstKeys))) {
+                return false;
+            }
+
+            // Each key must be the same value
+            foreach($firstValue as $key => $value) {
+                if (!self::_recursiveCompare($value, $secondValue[$key])) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (is_object($firstValue) && is_object($secondValue)) {
+            // For now this does not seem relevant
+            return false;
+        }
+
+        return $firstValue === $secondValue;
+    }
+
+    private static function _compareComplexValues($fields, $key, $firstValue, $secondValue): bool
+    {
+        // When the values are nested arrays we are probably comparing matrix elements
+        if (Hash::check($fields, $key)
+            && is_array($firstValue)
+            && is_array($secondValue)
+            && array_reduce($firstValue, static fn($carry, $item) => $carry && is_array($item), true)
+            && array_reduce($secondValue, static fn($carry, $item) => $carry && is_array($item), true)
+        ) {
+            // Compare the values recursively while ignoring the keys at the first level,
+            // these keys are statically set to `'newX'` and the ids for the values in the database
+            // so they have no meaning here
+            return self::_recursiveCompare(array_values($firstValue), array_values($secondValue));
         }
 
         // Didn't match


### PR DESCRIPTION
Currently the comparison fails when importing matrixes, this causes imports to incorrectly assume that the data changed and hence resulting in more database work, unncessessary revisions and a less efficient import alltogether.

I'm not sure in what version you would like this fix to be applied.  Give a shout if I have to move it around.

### Related issues
https://github.com/craftcms/feed-me/issues/1291

