### PR TITLE
support for importing entries with custom propagation

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -61,7 +61,7 @@ class Plugin extends \craft\base\Plugin
         ];
     }
 
-    public string $minVersionRequired = '4.4.0';
+    public string $minVersionRequired = '4.4.8';
     public string $schemaVersion = '5.1.0.0';
     public bool $hasCpSettings = true;
     public bool $hasCpSection = true;

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -157,6 +157,7 @@ class Entry extends Element
      * @throws Exception
      * @throws \craft\errors\SiteNotFoundException
      * @throws \craft\errors\UnsupportedSiteException
+     * @since 5.1.3
      */
     public function checkPropagation($existingElement, array $feed)
     {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -98,14 +98,16 @@ class Entry extends Element
     public function getQuery($settings, array $params = []): mixed
     {
         $targetSiteId = Hash::get($settings, 'siteId') ?: Craft::$app->getSites()->getPrimarySite()->id;
-        $section = $this->element->getSection();
+        if ($this->element !== null) {
+            $section = $this->element->getSection();
+        }
 
         $query = EntryElement::find()
             ->status(null)
             ->sectionId($settings['elementGroup'][EntryElement::class]['section'])
             ->typeId($settings['elementGroup'][EntryElement::class]['entryType']);
 
-        if ($section->propagationMethod === Section::PROPAGATION_METHOD_CUSTOM) {
+        if (isset($section) && $section->propagationMethod === Section::PROPAGATION_METHOD_CUSTOM) {
             $query->site('*')
                 ->preferSites([$targetSiteId])
                 ->unique();

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -13,6 +13,7 @@ use craft\feedme\base\Element;
 use craft\feedme\helpers\DataHelper;
 use craft\feedme\models\ElementGroup;
 use craft\feedme\Plugin;
+use craft\helpers\ElementHelper;
 use craft\helpers\Json;
 use craft\models\Section;
 use DateTime;
@@ -96,11 +97,22 @@ class Entry extends Element
      */
     public function getQuery($settings, array $params = []): mixed
     {
+        $targetSiteId = Hash::get($settings, 'siteId') ?: Craft::$app->getSites()->getPrimarySite()->id;
+        $section = $this->element->getSection();
+
         $query = EntryElement::find()
             ->status(null)
             ->sectionId($settings['elementGroup'][EntryElement::class]['section'])
-            ->typeId($settings['elementGroup'][EntryElement::class]['entryType'])
-            ->siteId(Hash::get($settings, 'siteId') ?: Craft::$app->getSites()->getPrimarySite()->id);
+            ->typeId($settings['elementGroup'][EntryElement::class]['entryType']);
+
+        if ($section->propagationMethod === Section::PROPAGATION_METHOD_CUSTOM) {
+            $query->site('*')
+                ->preferSites([$targetSiteId])
+                ->unique();
+        } else {
+            $query->siteId($targetSiteId);
+        }
+
         Craft::configure($query, $params);
         return $query;
     }
@@ -134,6 +146,40 @@ class Entry extends Element
         $this->element->setEnabledForSite($enabledForSite);
 
         return $this->element;
+    }
+
+    /**
+     * Checks if $existingElement should be propagated to the target site.
+     *
+     * @param $existingElement
+     * @param array $feed
+     * @return ElementInterface|null
+     * @throws Exception
+     * @throws \craft\errors\SiteNotFoundException
+     * @throws \craft\errors\UnsupportedSiteException
+     */
+    public function checkPropagation($existingElement, array $feed)
+    {
+        $targetSiteId = Hash::get($feed, 'siteId') ?: Craft::$app->getSites()->getPrimarySite()->id;
+
+        // Did the entry come back in a different site?
+        if ($existingElement->siteId != $targetSiteId) {
+            // Skip it if its section doesn't use the `custom` propagation method
+            if ($existingElement->getSection()->propagationMethod !== Section::PROPAGATION_METHOD_CUSTOM) {
+                return $existingElement;
+            }
+
+            // Give the entry a status for the import's target site
+            // (This is how the `custom` propagation method knows which sites the entry should support.)
+            $siteStatuses = ElementHelper::siteStatusesForElement($existingElement);
+            $siteStatuses[$targetSiteId] = $existingElement->getEnabledForSite();
+            $existingElement->setEnabledForSite($siteStatuses);
+
+            // Propagate the entry, and swap $entry with the propagated copy
+            return Craft::$app->getElements()->propagateElement($existingElement, $targetSiteId);
+        }
+
+        return $existingElement;
     }
 
     // Protected Methods

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -275,6 +275,10 @@ class Process extends Component
 
             // If we're deleting or updating an existing element, we want to focus on that one
             if (DuplicateHelper::isUpdate($feed)) {
+                if (method_exists($this->_service, 'checkPropagation')) {
+                    $existingElement = $this->_service->checkPropagation($existingElement, $feed);
+                }
+
                 $element = clone $existingElement;
 
                 // Update our service with the correct element


### PR DESCRIPTION
### Description
When importing entries to a section with the custom propagation method, check if the entry exists for other sites supported by this section. If it does, enable it for the site we’re importing to before updating the content.

Only applicable to v5 and requires Craft 4.4.8.

### Related issues
#1279 
