### PR TITLE
add formatting dropdown to mapping dated for products

### DIFF
--- a/src/templates/_includes/elements/commerce-products/map.html
+++ b/src/templates/_includes/elements/commerce-products/map.html
@@ -32,6 +32,7 @@
         type: 'text',
     },
 }, {
+    type: 'date',
     name: 'Post Date',
     handle: 'postDate',
     instructions: 'Accepts Unix timestamp, or just about any English textual datetime description.'|t('feed-me'),
@@ -39,6 +40,7 @@
         type: 'dateTime',
     },
 }, {
+    type: 'date',
     name: 'Expiry Date',
     handle: 'expiryDate',
     instructions: 'Accepts Unix timestamp, or just about any English textual datetime description.'|t('feed-me'),


### PR DESCRIPTION
### Description
Adds `type` to the `datetime` fields for the Commerce Products mapping screen. 
It’s only throwing an error in v5 but should be added to v4 and v5 for consistency.


To take effect, you need to re-save your feed, so that the date fields get the formatting option (currently missing from the mapping screen for Commerce Products).

### Related issues
#1287 
