### PR TITLE
logging level bug fix

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -79,9 +79,9 @@ class Settings extends Model
     public int $sleepTime = 0;
 
     /**
-     * @var bool
+     * @var bool|string
      */
-    public bool $logging = true;
+    public bool|string $logging = true;
 
     /**
      * @var bool

--- a/src/services/Logs.php
+++ b/src/services/Logs.php
@@ -170,7 +170,13 @@ class Logs extends Component
      */
     private function _canLog($type): bool
     {
-        $logging = Plugin::$plugin->service->getConfig('logging');
+        $loggingConfig = Plugin::$plugin->service->getConfig('logging');
+
+        // parse the config value because it need to allow for strings too to support 'error' level
+        $logging = App::parseBooleanEnv($loggingConfig);
+        if ($logging === null) {
+            $logging = $loggingConfig;
+        }
 
         // If logging set to false, don't log anything
         if ($logging === false) {


### PR DESCRIPTION
### Description
The `Settings` model `$logging` should allow for `bool` and `string`, so the logging level can be set to `'error'` as per the docs.

Only for v5.


### Related issues
#1295 
