### PR TITLE
fix for array_merge brought on by setEmptyValues works

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -84,6 +84,12 @@ class DataHelper
                     // Trim values in case whitespace was used between delimiter
                     $delimitedValues = array_map('trim', $delimitedValues);
 
+                    // we need the value to start as null for setEmptyValues
+                    // but we also need it to be an array at this point so that array_merge doesn't freak out
+                    // so if it's null so far, change it to an empty array as we're about to populate it with data
+                    if ($value === null) {
+                        $value = [];
+                    }
                     $value = array_merge($value, $delimitedValues);
                 } else {
                     $value[] = $nodeValue;
@@ -160,6 +166,12 @@ class DataHelper
                     // Trim values in case whitespace was used between delimiter
                     $delimitedValues = array_map('trim', $delimitedValues);
 
+                    // we need the value to start as null for setEmptyValues
+                    // but we also need it to be an array at this point so that array_merge doesn't freak out
+                    // so if it's null so far, change it to an empty array as we're about to populate it with data
+                    if ($value === null) {
+                        $value = [];
+                    }
                     $value = array_merge($value, $delimitedValues);
                 } else {
                     $value[] = $nodeValue;


### PR DESCRIPTION
### Description
Fixed a bug where having the `$value` set to `null` to start with (needed for `setEmptyValues)` was causing an error with `array_merge` if the field value was delimited.


### Related issues
#1298 
