### PR TITLE
respect bool and numeric values

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -207,7 +207,7 @@ class DataHelper
 
         // We want to preserve 0 and '0', but if it's empty, return null.
         // https://github.com/craftcms/feed-me/issues/779
-        if (!is_numeric($value) && empty($value)) {
+        if (!is_numeric($value) && !is_bool($value) && empty($value)) {
             return null;
         }
 

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -400,7 +400,9 @@ class Process extends Component
                 $fieldValue = Plugin::$plugin->fields->parseField($feed, $element, $feedData, $fieldHandle, $fieldInfo);
 
                 if ($fieldValue !== null) {
-                    if ($feed['setEmptyValues'] || !empty($fieldValue)) {
+                    if ($feed['setEmptyValues'] ||
+                        (!empty($fieldValue) || is_numeric($fieldValue) || is_bool($fieldValue))
+                    ) {
                         $fieldData[$fieldHandle] = $fieldValue;
                     }
                 }


### PR DESCRIPTION
### Description
After adding `setEmptyValues` boolean and numeric values (`false`, `0`) were not importing correctly if `setEmptyValues` was turned off.


### Related issues
#1329 
