### PR TITLE
money value in the feed should be float-like

### DIFF
--- a/src/fields/Money.php
+++ b/src/fields/Money.php
@@ -50,8 +50,16 @@ class Money extends Field implements FieldInterface
             return null;
         }
 
+        // we want the values in the feed to look like regular numbers,
+        // to be independent of the formatting locale
+        // for example if your money field is in EUR, the amount of
+        // one thousand two hundred thirty-four euro and fifty-six cents
+        // should be: 1234.56 in your feed;
+        // not 1234,56 or 1,234.56 or 1.234,56 - those values are all locale dependant strings
+        // not float-like values
         return [
             'value' => $value,
+            'locale' => 'en',
         ];
     }
 }

--- a/src/templates/_includes/fields/money.html
+++ b/src/templates/_includes/fields/money.html
@@ -1,0 +1,30 @@
+{# ------------------------ #}
+{# Available Variables #}
+{# ------------------------ #}
+{# Attributes: #}
+{# type, name, handle, instructions, attribute, default, feed, feedData #}
+{# ------------------------ #}
+{# Fields: #}
+{# name, handle, instructions, feed, feedData, field, fieldClass #}
+{# ------------------------ #}
+
+{% import 'feed-me/_macros' as feedMeMacro %}
+{% import '_includes/forms' as forms %}
+
+{% set default = default ?? {
+    type: 'text',
+} %}
+
+{% extends 'feed-me/_includes/fields/_base' %}
+
+{% block extraSettings %}
+    <div class="element-localized">
+        {{ forms.checkboxField({
+            name: 'options[localized]',
+            label: 'Data provided for this localized for the site the feed is for'|t('feed-me'),
+            class: '',
+            value: 1,
+            checked: hash_get(feed.fieldMapping, optionsPath ~ '.localized') ? true : false
+        }) }}
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Description
Adds money field template with “Data provided for this localized for the site the feed is for” checkbox. 
If checked, the value provided in the feed will be parsed as localised for the site you’re importing to. 
If left unchecked, a float-like notation will be used to parse.


Dutch number formatting uses a `full stop` as a **grouping character** and a `comma` as a **decimal character**.
Polish number formatting uses a `space` as a **grouping character** and a `comma` as a **decimal character**.
English number formatting uses a `comma` as a **grouping character** and a `full stop` as a **decimal character**.

You have a Money field with EUR currency.
You want to import a value of **one thousand two hundred thirty-four euro and fifty-six cents** into that field.

**Example 1:**
- the site you’re importing to has the language set to Dutch (nl)
- you checked the “Data provided for this localized for the site the feed is for” checkbox on the feed mapping screen
- the value in the feed should be: `1.234,56` (though not using the grouping character will work too)

**Example 2:**
- the site you’re importing to has the language set to Polish (pl)
- you checked the “Data provided for this localized for the site the feed is for” checkbox on the feed mapping screen
- the value in the feed should be: `1 234,56` (though not using the grouping character will work too)

**Example 3:**
- the site you’re importing to has the language set to English (en)
- you checked the “Data provided for this localized for the site the feed is for” checkbox on the feed mapping screen
- the value in the feed should be: `1,234.56` (though not using the grouping character will work too)

**Example 4:**
- it doesn’t matter what language is set on the site you’re importing to
- you **didn’t** check the “Data provided for this localized for the site the feed is for” checkbox on the feed mapping screen
- the value in the feed should be: `1234.56`


If, like in the original issue, you want to use the same data to import the Commerce price and value for a Money field, you should use the float-like notation and leave the “Data provided for this localized for the site the feed is for”  unchecked.

### Related issues
#1315 
