### PR TITLE
setEmptyValues for html fields (redactor, ckeditor)

### DIFF
--- a/src/fields/DefaultField.php
+++ b/src/fields/DefaultField.php
@@ -65,6 +65,13 @@ class DefaultField extends Field implements FieldInterface
             $value = $this->field->normalizeValue($value);
         }
 
+        // if we're setting empty values and the value is an empty string - return it
+        // otherwise HtmlField will serialize it to null, and we setEmptyValues won't take effect
+        // https://github.com/craftcms/feed-me/issues/1321
+        if ($this->feed['setEmptyValues'] === 1 && $value === '') {
+            return $value;
+        }
+
         // Lastly, get each field to prepare values how they should
         return $this->field->serializeValue($value);
     }


### PR DESCRIPTION
### Description
Allow to `setEmptyValues` for `HtmlField` type fields - Redactor, CKEditor.
`HtmlField->serializeValue` changes the empty string to `null`, which causes `setEmptyValues` to not take effect.


### Related issues
#1321 
