### PR TITLE
check if element enabled(forSite) attribute(s) changed

### DIFF
--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -242,6 +242,9 @@ class DataHelper
 
         $fields = $element->getSerializedFieldValues();
         $attributes = $element->attributes;
+        if (isset($attributes['enabled'])) {
+            $attributes['enabledForSite'] = $element->getEnabledForSite();
+        }
 
         foreach ($content as $key => $newValue) {
             $existingValue = Hash::get($fields, $key);

--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -372,6 +372,7 @@ class Process extends Component
         // Set the attributes for the element
         $element->setAttributes($attributeData, false);
 
+        $contentData = [];
         if (isset($attributeData['enabled'])) {
             // Set the site-specific status as well, but retain all other site statuses
             $enabledForSite = [];
@@ -387,6 +388,8 @@ class Process extends Component
             // Set the global status to true if it's enabled for *any* sites, or if already enabled.
             $element->enabled = in_array(true, $enabledForSite) || $element->enabled;
             $element->setEnabledForSite($enabledForSite);
+            $contentData['enabled'] = $element->enabled;
+            $contentData['enabledForSite'] = $element->getEnabledForSite($element->siteId);
         }
 
         // Then, do the same for custom fields. Again, this should be done after populating the element attributes
@@ -424,7 +427,7 @@ class Process extends Component
         }
 
         // We need to keep these separate to apply to the element but required when matching against existing elements
-        $contentData = $attributeData + $fieldData;
+        $contentData += $attributeData + $fieldData;
 
         //
         // It's time to actually save the element!


### PR DESCRIPTION
### Description
If element status is the only thing that should get updated, and the `compareContent` is set to `true` (default), the status wasn’t being updated because the content comparison check wasn’t taking `enabled` and `enabledForSite` into account.


### Related issues
#1310 
