### PR TITLE
trigger event_after_fetch_feed if feed path is local

### DIFF
--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -173,7 +173,13 @@ class DataTypes extends Component
             $filepath = realpath($url);
 
             if (!$filepath) {
-                return ['success' => false, 'error' => 'File path cannot be found.'];
+                $response = ['success' => false, 'error' => 'File path cannot be found.'];
+
+                return $this->_triggerEventAfterFetchFeed([
+                    'url' => $url,
+                    'feedId' => $feedId,
+                    'response' => $response,
+                ]);
             }
 
             $data = @file_get_contents($filepath);
@@ -188,15 +194,11 @@ class DataTypes extends Component
                 $response = ['success' => true, 'data' => $data];
             }
 
-            $event = new FeedDataEvent([
+            return $this->_triggerEventAfterFetchFeed([
                 'url' => $url,
                 'feedId' => $feedId,
                 'response' => $response,
             ]);
-
-            Event::trigger(static::class, self::EVENT_AFTER_FETCH_FEED, $event);
-
-            return $event->response;
         }
 
         try {
@@ -215,15 +217,11 @@ class DataTypes extends Component
             Craft::$app->getErrorHandler()->logException($e);
         }
 
-        $event = new FeedDataEvent([
+        return $this->_triggerEventAfterFetchFeed([
             'url' => $url,
             'feedId' => $feedId,
             'response' => $response,
         ]);
-
-        Event::trigger(static::class, self::EVENT_AFTER_FETCH_FEED, $event);
-
-        return $event->response;
     }
 
     /**
@@ -474,5 +472,20 @@ class DataTypes extends Component
     private function _getCache($url)
     {
         return Craft::$app->cache->get(base64_encode(urlencode($url)));
+    }
+
+    /**
+     * Trigger EVENT_AFTER_FETCH_FEED
+     *
+     * @param $data
+     * @return mixed
+     */
+    private function _triggerEventAfterFetchFeed($data)
+    {
+        $event = new FeedDataEvent($data);
+
+        Event::trigger(static::class, self::EVENT_AFTER_FETCH_FEED, $event);
+
+        return $event->response;
     }
 }

--- a/src/services/DataTypes.php
+++ b/src/services/DataTypes.php
@@ -188,7 +188,15 @@ class DataTypes extends Component
                 $response = ['success' => true, 'data' => $data];
             }
 
-            return $response;
+            $event = new FeedDataEvent([
+                'url' => $url,
+                'feedId' => $feedId,
+                'response' => $response,
+            ]);
+
+            Event::trigger(static::class, self::EVENT_AFTER_FETCH_FEED, $event);
+
+            return $event->response;
         }
 
         try {


### PR DESCRIPTION
### Description
Trigger the `EVENT_AFTER_FETCH_FEED` event if the feed is defined with a local path, too (e.g. `@webroot/feed-me/my-data.json`).


### Related issues
#1101 
