### PR TITLE
search through admins, credentialed and inactive if selected as a field source

### DIFF
--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -111,8 +111,6 @@ class Users extends Field implements FieldInterface
             if (in_array(UserElement::STATUS_INACTIVE, $sources, true)) {
                 $status[] = UserElement::STATUS_INACTIVE;
             }
-
-
         } elseif ($sources === '*') {
             $groupIds = null;
         }

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -5,6 +5,7 @@ namespace craft\feedme\fields;
 use Cake\Utility\Hash;
 use Craft;
 use craft\base\Element as BaseElement;
+use craft\elements\db\UserQuery;
 use craft\elements\User as UserElement;
 use craft\errors\ElementNotFoundException;
 use craft\feedme\base\Field;
@@ -85,12 +86,33 @@ class Users extends Field implements FieldInterface
 
         // Get source id's for connecting
         $groupIds = [];
+        $isAdmin = false;
+        $status = null;
 
         if (is_array($sources)) {
+            // go through sources that start with "group:" and get group uid for those
             foreach ($sources as $source) {
-                [, $uid] = explode(':', $source);
-                $groupIds[] = Db::idByUid('{{%usergroups}}', $uid);
+                if (str_starts_with($source, 'group:')) {
+                    [, $uid] = explode(':', $source);
+                    $groupIds[] = Db::idByUid('{{%usergroups}}', $uid);
+                }
             }
+
+            // the other possible source in Craft 4 can be 'admins' for which we'll need a separate query
+            if (in_array('admins', $sources, true)) {
+                $isAdmin = true;
+            }
+
+            // the other possible source in Craft 4 can be 'credentialed'
+            if (in_array(UserQuery::STATUS_CREDENTIALED, $sources, true)) {
+                $status[] = UserQuery::STATUS_CREDENTIALED;
+            }
+            // or 'inactive'
+            if (in_array(UserElement::STATUS_INACTIVE, $sources, true)) {
+                $status[] = UserElement::STATUS_INACTIVE;
+            }
+
+
         } elseif ($sources === '*') {
             $groupIds = null;
         }
@@ -125,22 +147,38 @@ class Users extends Field implements FieldInterface
                 $columnName = Craft::$app->getFields()->oldFieldColumnPrefix . $match;
             }
 
-            $query = UserElement::find();
-
+            $ids = [];
             $criteria['status'] = null;
             $criteria['groupId'] = $groupIds;
             $criteria['limit'] = $limit;
             $criteria['where'] = ['=', $columnName, $dataValue];
 
-            Craft::configure($query, $criteria);
+            // If the only source for the Users field is "admins" we don't have to bother with this query.
+            if (!($isAdmin && empty($groupIds))) {
+                $ids = $this->_findUsers($criteria);
+                $foundElements = array_merge($foundElements, $ids);
+            }
 
-            Plugin::info('Search for existing user with query `{i}`', ['i' => Json::encode($criteria)]);
+            // Previous query would look through selected groups or if "all" was selected
+            // (in which case groupIds would be null, and wouldn't actually limit the query).
+            // So if we haven't found a match with the previous query, and field sources contains "admins",
+            // we have to look for the user among admins too.
+            if ($isAdmin && count($ids) === 0) {
+                unset($criteria['groupId']);
+                $criteria['admin'] = true;
 
-            $ids = $query->ids();
+                $ids = $this->_findUsers($criteria);
+                $foundElements = array_merge($foundElements, $ids);
+            }
 
-            $foundElements = array_merge($foundElements, $ids);
+            // If we still have no matches, check based on the credentialed/inactive status
+            if (!empty($status) && count($ids) === 0) {
+                unset($criteria['groupId'], $criteria['admin']);
+                $criteria['status'] = $status;
 
-            Plugin::info('Found `{i}` existing users: `{j}`', ['i' => count($foundElements), 'j' => Json::encode($foundElements)]);
+                $ids = $this->_findUsers($criteria);
+                $foundElements = array_merge($foundElements, $ids);
+            }
 
             // Check if we should create the element. But only if email is provided (for the moment)
             if ((count($ids) == 0) && $create && $match === 'email') {
@@ -206,5 +244,25 @@ class Users extends Field implements FieldInterface
         }
 
         return $element->id;
+    }
+
+    /**
+     * Attempt to find User based on search criteria. Return array of found IDs.
+     *
+     * @param $criteria
+     * @return array|int[]
+     */
+    private function _findUsers($criteria): array
+    {
+        $query = UserElement::find();
+        Craft::configure($query, $criteria);
+
+        Plugin::info('Search for existing user with query `{i}`', ['i' => json_encode($criteria)]);
+
+        $ids = $query->ids();
+
+        Plugin::info('Found `{i}` existing users: `{j}`', ['i' => count($ids), 'j' => json_encode($ids)]);
+
+        return $ids;
     }
 }


### PR DESCRIPTION
### Description
v5 version of [PR 1337](https://github.com/craftcms/feed-me/pull/1337).
It has the same approach to handling groups and admins, and adds handling of `credentialed` and `inactive` sources.

### Related issues
#844
