### PR TITLE
match and create elements with title or slug "zero"

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -63,9 +63,13 @@ class Categories extends Field implements FieldInterface
             return null;
         }
 
+        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
+        $specialMatchCase = in_array($match, ['title', 'slug']);
+
         // if value from the feed is empty and default is not set
-        // return an empty array; no point bothering further
-        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+        // return an empty array; no point bothering further;
+        // but we need to allow for zero as a string ("0") value if we're matching by title or slug
+        if (empty($default) && DataHelper::isArrayValueEmpty($value, $specialMatchCase)) {
             return [];
         }
 
@@ -73,7 +77,6 @@ class Categories extends Field implements FieldInterface
         $branchLimit = Hash::get($this->field, 'settings.branchLimit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
-        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
@@ -87,7 +90,8 @@ class Categories extends Field implements FieldInterface
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue) && empty($default)) {
+            // but sometimes allow for zeros
+            if (empty($dataValue) && empty($default) && ($specialMatchCase && !is_numeric($dataValue))) {
                 continue;
             }
 

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -62,9 +62,12 @@ class CommerceProducts extends Field implements FieldInterface
             return null;
         }
 
+        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
+        $specialMatchCase = in_array($match, ['title', 'slug']);
+
         // if value from the feed is empty and default is not set
         // return an empty array; no point bothering further
-        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+        if (empty($default) && DataHelper::isArrayValueEmpty($value, $specialMatchCase)) {
             return [];
         }
 
@@ -72,7 +75,6 @@ class CommerceProducts extends Field implements FieldInterface
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
-        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
         $node = Hash::get($this->fieldInfo, 'node');
 
         $typeIds = [];
@@ -90,7 +92,8 @@ class CommerceProducts extends Field implements FieldInterface
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue) && empty($default)) {
+            // but sometimes allow for zeros
+            if (empty($dataValue) && empty($default) && ($specialMatchCase && !is_numeric($dataValue))) {
                 continue;
             }
 

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -61,9 +61,12 @@ class CommerceVariants extends Field implements FieldInterface
             return null;
         }
 
+        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
+        $specialMatchCase = $match === 'title';
+
         // if value from the feed is empty and default is not set
         // return an empty array; no point bothering further
-        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+        if (empty($default) && DataHelper::isArrayValueEmpty($value, $specialMatchCase)) {
             return [];
         }
 
@@ -71,7 +74,6 @@ class CommerceVariants extends Field implements FieldInterface
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
-        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
         $node = Hash::get($this->fieldInfo, 'node');
 
         $typeIds = [];
@@ -89,7 +91,8 @@ class CommerceVariants extends Field implements FieldInterface
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue) && empty($default)) {
+            // but sometimes allow for zeros
+            if (empty($dataValue) && empty($default) && ($specialMatchCase && !is_numeric($dataValue))) {
                 continue;
             }
 

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -63,9 +63,12 @@ class DigitalProducts extends Field implements FieldInterface
             return null;
         }
 
+        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
+        $specialMatchCase = in_array($match, ['title', 'slug']);
+
         // if value from the feed is empty and default is not set
         // return an empty array; no point bothering further
-        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+        if (empty($default) && DataHelper::isArrayValueEmpty($value, $specialMatchCase)) {
             return [];
         }
 
@@ -73,7 +76,6 @@ class DigitalProducts extends Field implements FieldInterface
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
-        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
         $node = Hash::get($this->fieldInfo, 'node');
 
         $typeIds = [];
@@ -91,7 +93,8 @@ class DigitalProducts extends Field implements FieldInterface
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue) && empty($default)) {
+            // but sometimes allow for zeros
+            if (empty($dataValue) && empty($default) && ($specialMatchCase && !is_numeric($dataValue))) {
                 continue;
             }
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -63,9 +63,13 @@ class Entries extends Field implements FieldInterface
             return null;
         }
 
+        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
+        $specialMatchCase = in_array($match, ['title', 'slug']);
+
         // if value from the feed is empty and default is not set
-        // return an empty array; no point bothering further
-        if (empty($default) && DataHelper::isArrayValueEmpty($value)) {
+        // return an empty array; no point bothering further;
+        // but we need to allow for zero as a string ("0") value if we're matching by title or slug
+        if (empty($default) && DataHelper::isArrayValueEmpty($value, $specialMatchCase)) {
             return [];
         }
 
@@ -73,7 +77,6 @@ class Entries extends Field implements FieldInterface
         $limit = Hash::get($this->field, 'settings.limit');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
-        $match = Hash::get($this->fieldInfo, 'options.match', 'title');
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');
         $node = Hash::get($this->fieldInfo, 'node');
@@ -101,7 +104,8 @@ class Entries extends Field implements FieldInterface
 
         foreach ($value as $dataValue) {
             // Prevent empty or blank values (string or array), which match all elements
-            if (empty($dataValue) && empty($default)) {
+            // but sometimes allow for zeros
+            if (empty($dataValue) && empty($default) && ($specialMatchCase && !is_numeric($dataValue))) {
                 continue;
             }
 

--- a/src/helpers/DataHelper.php
+++ b/src/helpers/DataHelper.php
@@ -20,11 +20,20 @@ class DataHelper
      * Check if provided value is not set or empty or an array of empties
      *
      * @param $value
+     * @param $allowZero bool Whether to treat zero as an empty value or not
      * @return bool
      */
-    public static function isArrayValueEmpty($value)
+    public static function isArrayValueEmpty($value, $allowZero = false): bool
     {
-        return (!$value || (is_array($value) && empty(array_filter($value))));
+        return (!$value ||
+            (is_array($value) && empty(array_filter($value, function($item) use ($allowZero): bool {
+                if ($allowZero) {
+                    return (!empty($item) || is_numeric($item));
+                }
+
+                return !empty($item);
+            })))
+        );
     }
 
     /**


### PR DESCRIPTION
### Description
In the CMS, it is possible to create elements with the title (or slug) set to `"0"` or `"false"`. Feed Me can have trouble finding (and creating) elements with the title (or slug) of `"0"`.

Allow to match and create Category, Entry, Product, and Digital Product with title or slug set to a zero in the feed.
For Product Variant, do the same but just for the title.


### Related issues
#1102 
