### PR TITLE
respect importing valid slugs

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -14,6 +14,7 @@ use craft\feedme\helpers\DataHelper;
 use craft\feedme\helpers\DateHelper;
 use craft\feedme\models\FeedModel;
 use craft\helpers\Db;
+use craft\helpers\ElementHelper;
 use craft\helpers\StringHelper;
 
 /**
@@ -303,6 +304,12 @@ abstract class Element extends Component implements ElementInterface
 
         if (Craft::$app->getConfig()->getGeneral()->limitAutoSlugsToAscii) {
             $value = $this->_asciiString($value);
+        }
+
+        // normalize the slug and check if it's valid;
+        // if it is - use it, otherwise _createSlug()
+        if (is_string($value) && ($value = ElementHelper::normalizeSlug($value)) !== '') {
+            return $value;
         }
 
         return $this->_createSlug($value);


### PR DESCRIPTION
### Description
This PR adjust the slug-importing behaviour. If the slug from the feed is considered valid (after normalization), it will be used; otherwise, it will do what it does now - run it through the [`_createSlug()` method](https://github.com/craftcms/feed-me/blob/develop/src/base/Element.php#L350-L359), which will turn it into a kebab-cased string. 

Before this change (assuming you haven’t changed the  `slugWordSeparator` config):
- if you have a slug: `test_1` in your feed, it will be imported as `test-1`
- if you have a slug: `tes't_1` in your feed, it will be imported as `test-1`
- if you have a slug: `test-1` in your feed, it will be imported as `test-1`
- if you have a slug: `test 1` in your feed, it will be imported as `test-1`

After:
- if you have a slug: `test_1` in your feed, it will be imported as `test_1`
- if you have a slug: `tes't_1` in your feed, it will be imported as `test_1`
- if you have a slug: `test-1` in your feed, it will be imported as `test-1`
- if you have a slug: `test 1` in your feed, it will be imported as `test-1`


### Related issues
#603 
