### PR TITLE
allow parent to be a unique identifier

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -162,7 +162,6 @@ abstract class Element extends Component implements ElementInterface
                 } else {
                     $criteria[$handle] = Db::escapeParam($feedValue);
                 }
-
             }
         }
 

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -157,7 +157,12 @@ abstract class Element extends Component implements ElementInterface
                     continue;
                 }
 
-                $criteria[$handle] = Db::escapeParam($feedValue);
+                if ($handle === 'parent') {
+                    $criteria['descendantOf'] = Db::escapeParam($feedValue);
+                } else {
+                    $criteria[$handle] = Db::escapeParam($feedValue);
+                }
+
             }
         }
 

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -269,6 +269,10 @@ class FeedMeVariable extends ServiceLocator
     {
         $type = $field['type'] ?? 'attribute';
 
+        if (isset($field['type']) && $field['handle'] === 'parent') {
+            $type = 'parent';
+        }
+
         if (is_object($field)) {
             $type = get_class($field);
         }
@@ -290,6 +294,7 @@ class FeedMeVariable extends ServiceLocator
         $supportedValues = [
             'assets',
             'attribute',
+            'parent'
         ];
 
         $supported = array_merge($supportedFields, $supportedValues);

--- a/src/web/twig/variables/FeedMeVariable.php
+++ b/src/web/twig/variables/FeedMeVariable.php
@@ -294,7 +294,7 @@ class FeedMeVariable extends ServiceLocator
         $supportedValues = [
             'assets',
             'attribute',
-            'parent'
+            'parent',
         ];
 
         $supported = array_merge($supportedFields, $supportedValues);


### PR DESCRIPTION
### Description
Allow the parent field to be a unique identifier. 
It can be used along with, e.g. the title to allow to import a unique structure like this: 

<img width="2087" alt="Screenshot 2023-06-30 at 16 09 59" src="https://github.com/craftcms/feed-me/assets/4500340/ab9cf099-7b69-467c-b9ed-a7031200ab9e">

### Related issues
#780 
