### PR TITLE
Fix: Entries in site-group sites disabled when importing to a specific site

### DIFF
--- a/src/services/Process.php
+++ b/src/services/Process.php
@@ -381,11 +381,8 @@ class Process extends Component
         if (isset($attributeData['enabled'])) {
             // Set the site-specific status as well, but retain all other site statuses
             $enabledForSite = [];
-            foreach (Craft::$app->getSites()->getAllSiteIds(true) as $siteId) {
-                $status = $element->getEnabledForSite($siteId);
-                if ($status !== null) {
-                    $enabledForSite[$siteId] = $status;
-                }
+            foreach (Craft::$app->getElements()->getEnabledSiteIdsForElement($element->id) as $siteId) {
+                $enabledForSite[$siteId] = true;
             }
 
             $enabledForSite[$element->siteId] = $attributeData['enabled'];


### PR DESCRIPTION
### Description
Using `$element->getEnabledForSite($siteId);` with the `$site` param always returns `false`.
On the Element in craftcms/cms https://github.com/craftcms/cms/blob/4.4.15/src/base/Element.php#L3339 the `$this->_enabledForSite` is never an array.

Switching this logic out for the Elements service fixes this issue.


### Related issues
This fixes the reccuring issue in #1208
