### PR TITLE
handle entrified categories and tags fields

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -272,6 +272,10 @@ class Matrix extends Field implements FieldInterface
 
         $subField = Hash::extract($this->field->getBlockTypeFields(), '{n}[handle=' . $subFieldHandle . ']')[0];
 
+        if (!$subField instanceof $subFieldClassHandle) {
+            $subFieldClassHandle = \craft\fields\Entries::class;
+        }
+
         $class = Plugin::$plugin->fields->getRegisteredField($subFieldClassHandle);
         $class->feedData = $feedData;
         $class->fieldHandle = $subFieldHandle;

--- a/src/fields/SuperTable.php
+++ b/src/fields/SuperTable.php
@@ -224,6 +224,10 @@ class SuperTable extends Field implements FieldInterface
 
         $subField = Hash::extract($this->field->getBlockTypeFields(), '{n}[handle=' . $subFieldHandle . ']')[0];
 
+        if (!$subField instanceof $subFieldClassHandle) {
+            $subFieldClassHandle = \craft\fields\Entries::class;
+        }
+
         $class = Plugin::$plugin->fields->getRegisteredField($subFieldClassHandle);
         $class->feedData = $feedData;
         $class->fieldHandle = $subFieldHandle;

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -205,12 +205,21 @@ class Fields extends Component
 
         $fieldClassHandle = Hash::get($fieldInfo, 'field');
 
+        // if category groups or tag groups have been entrified, the fields for them could have been entrified too;
+        // get the field by handle, check if the type hasn't changed since the feed was last saved;
+        // if it hasn't changed - proceed as before
+        // if it has changed - assume that we've entrified and adjust the $fieldClassHandle
+        $field = Craft::$app->getFields()->getFieldByHandle($fieldHandle);
+        if (!$field instanceof $fieldClassHandle) {
+            $fieldClassHandle = \craft\fields\Entries::class;
+        }
+
         // Find the class to deal with the attribute
         $class = $this->getRegisteredField($fieldClassHandle);
         $class->feedData = $feedData;
         $class->fieldHandle = $fieldHandle;
         $class->fieldInfo = $fieldInfo;
-        $class->field = Craft::$app->getFields()->getFieldByHandle($fieldHandle);
+        $class->field = $field;
         $class->element = $element;
         $class->feed = $feed;
 


### PR DESCRIPTION
### Description
If Categories or Tags have been entrified, the fields could have been changed to Entries field, but the feed still refers to them by their original type. Because of that, check if the field we got by handle matches the type saved in the feed, and if it doesn’t, use the Entries field type.

Once the feed is saved after entrification, the field type gets updated, so the code that changes the field type won’t be executed anymore.

(Just for Craft 4.) 


### Related issues
#1340 
