### PR TITLE
use maxRelations, not limit for the relational fields

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -77,7 +77,7 @@ class Assets extends Field implements FieldInterface
 
         $settings = Hash::get($this->field, 'settings');
         $folders = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $upload = Hash::get($this->fieldInfo, 'options.upload');

--- a/src/fields/CalendarEvents.php
+++ b/src/fields/CalendarEvents.php
@@ -69,7 +69,7 @@ class CalendarEvents extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $match = Hash::get($this->fieldInfo, 'options.match', 'title');

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -76,7 +76,13 @@ class Categories extends Field implements FieldInterface
         }
 
         $source = Hash::get($this->field, 'settings.source');
-        $branchLimit = Hash::get($this->field, 'settings.branchLimit');
+        $maintainHierarchy = Hash::get($this->field, 'settings.maintainHierarchy');
+        if ($maintainHierarchy) {
+            $limit = Hash::get($this->field, 'settings.branchLimit');
+        } else {
+            $limit = Hash::get($this->field, 'settings.maxRelations');
+        }
+
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $create = Hash::get($this->fieldInfo, 'options.create');
@@ -135,7 +141,7 @@ class Categories extends Field implements FieldInterface
 
             $criteria['status'] = null;
             $criteria['groupId'] = $groupId;
-            $criteria['limit'] = $branchLimit;
+            $criteria['limit'] = $limit;
             $criteria['where'] = ['=', $columnName, $dataValue];
 
             Craft::configure($query, $criteria);
@@ -157,8 +163,8 @@ class Categories extends Field implements FieldInterface
         }
 
         // Check for field limit - only return the specified amount
-        if ($foundElements && $branchLimit) {
-            $foundElements = array_chunk($foundElements, $branchLimit)[0];
+        if ($foundElements && $limit) {
+            $foundElements = array_chunk($foundElements, $limit)[0];
         }
 
         // Check for any sub-fields for the element

--- a/src/fields/CommerceProducts.php
+++ b/src/fields/CommerceProducts.php
@@ -74,7 +74,7 @@ class CommerceProducts extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $node = Hash::get($this->fieldInfo, 'node');

--- a/src/fields/CommerceVariants.php
+++ b/src/fields/CommerceVariants.php
@@ -73,7 +73,7 @@ class CommerceVariants extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $node = Hash::get($this->fieldInfo, 'node');

--- a/src/fields/DigitalProducts.php
+++ b/src/fields/DigitalProducts.php
@@ -74,7 +74,7 @@ class DigitalProducts extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $node = Hash::get($this->fieldInfo, 'node');

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -79,7 +79,7 @@ class Entries extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $targetSiteId = Hash::get($this->field, 'settings.targetSiteId');
         $feedSiteId = Hash::get($this->feed, 'siteId');
         $create = Hash::get($this->fieldInfo, 'options.create');

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -77,7 +77,7 @@ class Users extends Field implements FieldInterface
         }
 
         $sources = Hash::get($this->field, 'settings.sources');
-        $limit = Hash::get($this->field, 'settings.limit');
+        $limit = Hash::get($this->field, 'settings.maxRelations');
         $match = Hash::get($this->fieldInfo, 'options.match', 'email');
         $create = Hash::get($this->fieldInfo, 'options.create');
         $fields = Hash::get($this->fieldInfo, 'fields');


### PR DESCRIPTION
### Description
When importing into relational fields, use the new `maxRelations` setting, not the old `limit`.


### Related issues
#1354 
