### PR TITLE
don't ignore feed options

### DIFF
--- a/src/helpers/AssetHelper.php
+++ b/src/helpers/AssetHelper.php
@@ -21,11 +21,12 @@ class AssetHelper
      * @param $dstName
      * @param int $chunkSize
      * @param bool $returnbytes
+     * @param null|int $feedId
      * @return bool|int
      */
-    public static function downloadFile($srcName, $dstName, $chunkSize = 1, $returnbytes = true)
+    public static function downloadFile($srcName, $dstName, $chunkSize = 1, $returnbytes = true, $feedId = null)
     {
-        $assetDownloadCurl = Plugin::$plugin->getSettings()->assetDownloadCurl;
+        $assetDownloadCurl = Plugin::$plugin->service->getConfig('assetDownloadCurl', $feedId);
 
         // Provide some legacy support
         if ($assetDownloadCurl) {
@@ -106,7 +107,7 @@ class AssetHelper
                 Plugin::info('Fetching remote image `{i}` - `{j}`', ['i' => $url, 'j' => $filename]);
 
                 if (!$cachedImage) {
-                    self::downloadFile($url, $fetchedImage);
+                    self::downloadFile($url, $fetchedImage, 1, true, $feed['id']);
                 } else {
                     $fetchedImage = $cachedImage[0];
                 }

--- a/src/queue/jobs/FeedImport.php
+++ b/src/queue/jobs/FeedImport.php
@@ -51,7 +51,7 @@ class FeedImport extends BaseJob implements RetryableJobInterface
      */
     public function getTtr()
     {
-        return Plugin::$plugin->getSettings()->queueTtr ?? Plugin::getInstance()->queue->ttr;
+        return Plugin::$plugin->service->getConfig('queueTtr', $this->feed->id) ?? Plugin::getInstance()->queue->ttr;
     }
 
     /**
@@ -59,7 +59,7 @@ class FeedImport extends BaseJob implements RetryableJobInterface
      */
     public function canRetry($attempt, $error)
     {
-        $attempts = Plugin::$plugin->getSettings()->queueMaxRetry ?? Plugin::getInstance()->queue->attempts;
+        $attempts = Plugin::$plugin->service->getConfig('queueMaxRetry', $this->feed->id) ?? Plugin::getInstance()->queue->attempts;
         return $attempt < $attempts;
     }
 


### PR DESCRIPTION
### Description
Don’t ignore `queueTtr`, `queueMaxRetry` and `assetDownloadCurl` feed options.


### Related issues
#1356 
