### PR TITLE
Bugfix/1348 importing assets to remote fs creates duplicates

### DIFF
--- a/src/helpers/AssetHelper.php
+++ b/src/helpers/AssetHelper.php
@@ -17,7 +17,6 @@ use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 use craft\models\AssetIndexData;
 use craft\models\FsListing;
-use craft\models\Volume;
 use craft\models\VolumeFolder;
 use Throwable;
 use yii\base\Exception;

--- a/src/helpers/AssetHelper.php
+++ b/src/helpers/AssetHelper.php
@@ -100,8 +100,13 @@ class AssetHelper
      * @throws \craft\errors\VolumeException
      * @throws \yii\base\InvalidConfigException
      */
-    public static function indexExistingFile($urlFromFeed, $field = null, $element = null, $folderId = null, $newFilename = null): AssetElement|bool
+    public static function indexExistingFile($urlFromFeed, string $conflict, $field = null, $element = null, $folderId = null, $newFilename = null): AssetElement|bool
     {
+        // if the conflict strategy is to replace or create, just bail straight away
+        // and allow for creation of the asset even the file exists
+        if ($conflict == AssetElement::SCENARIO_REPLACE || $conflict == AssetElement::SCENARIO_CREATE) {
+            return false;
+        }
         $folder = self::_getAssetFolder($folderId, $field, $element);
         $volume = $folder->getVolume();
         $filename = $newFilename ? AssetsHelper::prepareAssetName($newFilename, false) : self::getRemoteUrlFilename($urlFromFeed);
@@ -166,7 +171,7 @@ class AssetHelper
         // user has set to use that instead, so we're good to proceed.
         foreach ($urls as $url) {
             try {
-                $indexedAsset = self::indexExistingFile($url, $field, $element, $folderId, $newFilename);
+                $indexedAsset = self::indexExistingFile($url, $conflict, $field, $element, $folderId, $newFilename);
 
                 if ($indexedAsset instanceof AssetElement) {
                     $uploadedAssets[] = $indexedAsset->id;


### PR DESCRIPTION
### Description
When importing remote files into asset elements or the assets field, check if the file already exists (by filename) in the destination location. If it does, “index” it instead of re-uploading and therefore creating a duplicate file.


### Related issues
#1348 
