### PR TITLE
allow to override to `false` value

### DIFF
--- a/src/services/Feeds.php
+++ b/src/services/Feeds.php
@@ -288,7 +288,7 @@ class Feeds extends Component
         foreach ($attributes as $attribute => $value) {
             $override = $this->getModelOverrides($attribute, $record['id']);
 
-            if ($override) {
+            if ($override !== null) {
                 $attributes[$attribute] = $override;
             }
         }


### PR DESCRIPTION
### Description
When overriding feed settings via `config/feed-me.php` account for setting a value to `false`.


### Related issues
#1380 
