### PR TITLE
fix for importing inner element fields

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -167,7 +167,7 @@ abstract class Field extends Component
 
                 // Arrayed content doesn't provide defaults because its unable to determine how many items it _should_ return
                 // This also checks if there was any data that corresponds on the same array index/level as our element
-                $value = Hash::get($fieldValue, $nodeKey, $default);
+                $value = Hash::get($fieldValue, $nodeKey ?? $key, $default);
 
                 if ($value) {
                     $fieldData[$elementId][$fieldHandle] = $value;

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -167,6 +167,7 @@ abstract class Field extends Component
 
                 // Arrayed content doesn't provide defaults because its unable to determine how many items it _should_ return
                 // This also checks if there was any data that corresponds on the same array index/level as our element
+                /** @phpstan-ignore-next-line */
                 $value = Hash::get($fieldValue, $nodeKey ?? $key, $default);
 
                 if ($value) {


### PR DESCRIPTION
### Description
Commit https://github.com/craftcms/feed-me/commit/27dac31b8a6070d8e15d480d5c55f6d2fa20af21 fixed [an issue](https://github.com/craftcms/feed-me/issues/1227) where matrix element inner fields were using the first set of data for all elements, but it broke “simple” inner element field import. This PR fixes it while keeping the inner fields for elements in a matrix field working as expected. 


### Related issues
#1378
