### PR TITLE
Bugfix/1375 empty headings fallback

### DIFF
--- a/src/datatypes/Csv.php
+++ b/src/datatypes/Csv.php
@@ -71,7 +71,7 @@ class Csv extends DataType implements DataTypeInterface
                 $col = 1;
                 foreach ($row as $key => $value) {
                     $newKey = preg_replace('#\r\n?#', " ", $key);
-                    if (empty(trim($newKey))) {
+                    if (trim($newKey) == '') {
                         $newKey = 'blank_heading_' . $col;
                     }
                     $filteredRow[$newKey] = $value;

--- a/src/datatypes/Csv.php
+++ b/src/datatypes/Csv.php
@@ -68,9 +68,14 @@ class Csv extends DataType implements DataTypeInterface
                 $filteredRow = [];
 
                 // Additional work here to handle line-breaks in keys (CSV header) - they're not allowed
+                $col = 1;
                 foreach ($row as $key => $value) {
                     $newKey = preg_replace('#\r\n?#', " ", $key);
+                    if (empty(trim($newKey))) {
+                        $newKey = 'blank_heading_' . $col;
+                    }
                     $filteredRow[$newKey] = $value;
+                    $col++;
                 }
 
                 // Check for empty rows - ditch them

--- a/src/datatypes/GoogleSheet.php
+++ b/src/datatypes/GoogleSheet.php
@@ -53,7 +53,7 @@ class GoogleSheet extends DataType implements DataTypeInterface
                 foreach ($row as $j => $column) {
                     $key = $headers[$j];
 
-                    if (empty(trim($key))) {
+                    if (trim($key) == '') {
                         $key = 'blank_heading_' . ($j+1);
                     }
 

--- a/src/datatypes/GoogleSheet.php
+++ b/src/datatypes/GoogleSheet.php
@@ -53,6 +53,10 @@ class GoogleSheet extends DataType implements DataTypeInterface
                 foreach ($row as $j => $column) {
                     $key = $headers[$j];
 
+                    if (empty(trim($key))) {
+                        $key = 'blank_heading_' . ($j+1);
+                    }
+
                     $array[$i][$key] = $column;
                 }
             }

--- a/src/datatypes/GoogleSheet.php
+++ b/src/datatypes/GoogleSheet.php
@@ -54,7 +54,7 @@ class GoogleSheet extends DataType implements DataTypeInterface
                     $key = $headers[$j];
 
                     if (trim($key) == '') {
-                        $key = 'blank_heading_' . ($j+1);
+                        $key = 'blank_heading_' . ($j + 1);
                     }
 
                     $array[$i][$key] = $column;

--- a/src/datatypes/Json.php
+++ b/src/datatypes/Json.php
@@ -62,6 +62,19 @@ class Json extends DataType implements DataTypeInterface
             return ['success' => false, 'error' => $error];
         }
 
+        // if we have empty keys in the array - throw an error, that's not allowed
+        $containsEmptyKeys = false;
+        array_walk_recursive($array, function($value, $key) use (&$containsEmptyKeys) {
+            if (trim($key) === '') {
+                $containsEmptyKeys = true;
+            }
+        });
+        if ($containsEmptyKeys) {
+            $error = 'Invalid Data: data contains empty headings (keys)';
+            Plugin::error($error);
+            return ['success' => false, 'error' => $error];
+        }
+
         // If using pagination, set it up here - we need to do this before messing around with the primary element
         $this->setupPaginationUrl($array, $settings);
 

--- a/src/templates/feeds/_map.html
+++ b/src/templates/feeds/_map.html
@@ -62,6 +62,12 @@
             <h2>{{ 'Unable to proceed to field mapping'|t('feed-me') }}</h2>
             <p>{{ 'Feed Me is unable to find, or parse your provided data. This usually means your URL cannot be reached from your Craft site, or your {feedType} is invalid. Check the logs, and double-check your settings.'|t('feed-me', { feedType: feed.feedType|upper }) }}</p>
 
+            {% if feedMappingData.error is not empty %}
+                <div class="fullpage-error-message">
+                    <code>{{ feedMappingData.error }}</code>
+                </div>
+            {% endif %}
+
             <div class="buttons">
                 <a href="{{ url('feed-me/feeds/' ~ feed.id) }}" class="btn submit">&larr; {{ 'Back to feed'|t('feed-me') }}</a>
                 <a href="{{ url('feed-me/logs') }}" class="btn submit">{{ 'Go to logs'|t('feed-me') }}</a>


### PR DESCRIPTION
### Description
When data contains an empty heading/key, the value for that column will be preselected under “Pagination URL” on the “Element” page and in the field mapping on the “Map” page.

- Google Sheet and CSV: those data types are 2 dimensional, so solved by adding `blank_heading_<column_index_number>` as the heading
<img width="1445" alt="Screenshot 2023-11-22 at 16 00 39" src="https://github.com/craftcms/feed-me/assets/4500340/700f2048-4ba7-4fc9-8358-2292600bc2b7">

- XML: doesn’t allow empty node names, so this problem doesn’t exist there.
<img width="1149" alt="Screenshot 2023-11-22 at 15 58 49" src="https://github.com/craftcms/feed-me/assets/4500340/1ae2d651-b5f1-463a-9bbf-22883cc1dbee">

- Atom and RSS: both use the same processing as XML.
- Json: because this can be deeply nested, I opted for throwing an error if empty keys are found.
<img width="1138" alt="Screenshot 2023-11-22 at 16 01 21" src="https://github.com/craftcms/feed-me/assets/4500340/a70e531e-7130-4238-8397-4ed8c842d96d">

Applicable to v4 and v5.

### Related issues
#1375 
