### PR TITLE
Bugfix/1762 asset folder ids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
   "extra": {
     "name": "Feed Me",
     "handle": "feed-me",
-    "documentationUrl": "https://docs.craftcms.com/feed-me/v4/"
+    "documentationUrl": "https://docs.craftcms.com/feed-me/v6"
   },
   "scripts": {
     "check-cs": "ecs check --ansi",

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -111,7 +111,7 @@ class Assets extends Field implements FieldInterface
                         ->where(['volumeId' => $volumeId])
                         ->column();
 
-                    $folderIds = array_merge($folderIds, $ids);
+                    $folderIds = array_merge($folderIds ?? [], $ids);
                 }
             }
         }


### PR DESCRIPTION
### Description
Fixes an issue where importing into an assets field that doesn't have "all volumes" selected and doesn't restrict uploads to a single location would throw an error.

(also updates documentation URL to point to v6)


### Related issues
#1762 
